### PR TITLE
Do not create debug.log

### DIFF
--- a/browserpass.go
+++ b/browserpass.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -133,7 +134,6 @@ func getLoginFromFile(file string) *Login {
 // write errors to log & quit
 func checkError(err error) {
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }

--- a/browserpass.go
+++ b/browserpass.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
-	"log"
 	"os"
 	"os/exec"
 	"strings"
@@ -18,17 +17,11 @@ var PwStoreDir string
 type Login struct {
 	Username string `json:"u"`
 	Password string `json:"p"`
-	File		 string `json:"f"`
+	File     string `json:"f"`
 }
 
 func main() {
 	PwStoreDir = getPasswordStoreDir()
-
-	// set logging
-	f, err := os.OpenFile("debug.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-	checkError(err)
-	defer f.Close()
-	log.SetOutput(f)
 
 	// listen for stdin
 	for {
@@ -140,6 +133,7 @@ func getLoginFromFile(file string) *Login {
 // write errors to log & quit
 func checkError(err error) {
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprintf(os.Stdout, "%v\n", err)
+		os.Exit(1)
 	}
 }

--- a/browserpass.go
+++ b/browserpass.go
@@ -133,7 +133,7 @@ func getLoginFromFile(file string) *Login {
 // write errors to log & quit
 func checkError(err error) {
 	if err != nil {
-		fmt.Fprintf(os.Stdout, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Installing browserpass system-wide doesn't work: browserpass tries to create debug.log which fails with "permission denied".

To see error messages, you can launch chromium from the console.