### PR TITLE
Adds link to Arch package

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ login: johndoe
 
 ## Installation
 
-Start out by downloading the [latest release package](https://github.com/dannyvankooten/browserpass/releases) for your operating system. Prebuilt binaries for 64-bit OSX & Linux are available.
+Start out by downloading the [latest release package](https://github.com/dannyvankooten/browserpass/releases) for your operating system. Prebuilt binaries for 64-bit OSX & Linux are available. Arch users can install browserpass [from the AUR](https://aur.archlinux.org/packages/browserpass/).
 
 #### Installing the host application
 


### PR DESCRIPTION
I created an Arch package for browserpass. It's not working for now because of #14, but as soon as a new version will be released it will be fixed.