### PR TITLE
support for user: field

### DIFF
--- a/browserpass.go
+++ b/browserpass.go
@@ -105,10 +105,11 @@ func parseLogin(b *bytes.Buffer) *Login {
 	// keep reading file for string in "login:" or "username:" format.
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.HasPrefix(line, "login:") || strings.HasPrefix(line, "username:") {
+		if strings.HasPrefix(line, "login:") || strings.HasPrefix(line, "username:") || strings.HasPrefix(line, "user:"){
 			login.Username = line
 			login.Username = strings.TrimLeft(login.Username, "login:")
 			login.Username = strings.TrimLeft(login.Username, "username:")
+			login.Username = strings.TrimLeft(login.Username, "user:")
 			login.Username = strings.TrimSpace(login.Username)
 		}
 	}


### PR DESCRIPTION
My pass gui saves all login fields as 'user:' instead of username so it would be great if you could support that too.