### PR TITLE
Avoid automatic form submit when there are two password fields, focus on the second field instead

### DIFF
--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -164,7 +164,13 @@ function fillLoginForm(login) {
 
     update(field('input[type=password]'), ${JSON.stringify(login.p)});
     update(field('input[type=email], input[type=text]'), ${JSON.stringify(login.u)});
-    field('[type=submit]').click();
+
+    var password_inputs = document.querySelectorAll('input[type=password]');
+    if (password_inputs.length > 1) {
+      password_inputs[1].select();
+    } else {
+      field('[type=submit]').click();
+    }
   })(document);
   `;
   chrome.tabs.executeScript({ code: code });


### PR DESCRIPTION
Fixes: https://github.com/dannyvankooten/browserpass/issues/27#issuecomment-270921623