### PR TITLE
Autoinstall the extension

### DIFF
--- a/chrome/browserpass.json
+++ b/chrome/browserpass.json
@@ -1,0 +1,5 @@
+{
+	"ExtensionInstallForcelist": [
+		"jegbgfamcgeocbfeebacnkociplhmfbk;https://clients2.google.com/service/update2/crx"
+	]
+}

--- a/install.sh
+++ b/install.sh
@@ -70,6 +70,8 @@ mkdir -p "$TARGET_DIR"
 if [ "$BROWSER" == "1" ] || [ "$BROWSER" == "2" ]; then
   echo "Installing Chrome / Chromium host config"
   cp "$DIR/chrome-host.json" "$TARGET_DIR/$APP_NAME.json"
+	mkdir -p "$TARGET_DIR"/../policies/managed/
+	cp "$DIR/browserpass.json" "$TARGET_DIR"/../policies/managed/"$APP_NAME.json"
 else
   echo "Installing Firefox host config"
   cp "$DIR/firefox-host.json" "$TARGET_DIR_FIREFOX/$APP_NAME.json"


### PR DESCRIPTION
Installing the extension from the chrome store will cause it to be
installed on every chrome browser your account is sync'd with.  Adding
a system policy that auto installs the extension will install it when
browserpass is available on the system but will leave it off of sync'd
devices that don't want it installed.  Browserpass uniquely has an AUR
package and therefore is one of the few google-chrome <--> pass
bridges that can incorporate this feature.