### PR TITLE
Search by domain.tld

### DIFF
--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -181,5 +181,5 @@ function fillLoginForm(login) {
 function parseDomainFromUrl(url) {
   var a = document.createElement('a');
   a.href = url;
-  return a.hostname.replace('www.', '');
+  return a.hostname.replace(/[a-z0-9-]+\.[a-z0-9-]+$/, '$&');
 }


### PR DESCRIPTION
Instead of the default search going by fully.qualified.domain.tld we
can default to domain.tld so that visiting accounts.google.com will
bring up passwords stored under google.com.  This is probably more
natural for most users.