### PR TITLE
Fix domain.TLD parsing

### DIFF
--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -177,9 +177,13 @@ function fillLoginForm(login) {
   window.close();
 }
 
+// Thanks to Simon Buchan at http://stackoverflow.com/questions/6449340/how-to-get-top-level-domain-base-domain-from-the-url-in-javascript
+var DOMAIN_REGEX = /[-\w]+\.(?:[-\w]+\.xn--[-\w]+|[-\w]{3,}|[-\w]+\.[-\w]{2})$/i;
+
 // parse domain from a URL & strip WWW
 function parseDomainFromUrl(url) {
   var a = document.createElement('a');
   a.href = url;
-  return a.hostname.replace(/[a-z0-9-]+\.[a-z0-9-]+$/, '$&');
+  var m = a.hostname.match(DOMAIN_REGEX);
+  return m && m[0];
 }

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var m = require('mithril');
+var parseDomain = require('parse-domain');
 var app = 'com.dannyvankooten.browserpass';
 var activeTab;
 var searching = false;
@@ -81,9 +82,9 @@ function init(tab) {
   }
 
   activeTab = tab;
-  var domain = parseDomainFromUrl(tab.url);
-  if( domain ) {
-    searchPassword(domain);
+  var parsedDomain = parseDomain(tab.url);
+  if( parsedDomain ) {
+    searchPassword(parsedDomain.domain + '.' + parsedDomain.tld);
   }
 }
 
@@ -175,15 +176,4 @@ function fillLoginForm(login) {
   `;
   chrome.tabs.executeScript({ code: code });
   window.close();
-}
-
-// Thanks to Simon Buchan at http://stackoverflow.com/questions/6449340/how-to-get-top-level-domain-base-domain-from-the-url-in-javascript
-var DOMAIN_REGEX = /[-\w]+\.(?:[-\w]+\.xn--[-\w]+|[-\w]{3,}|[-\w]+\.[-\w]{2})$/i;
-
-// parse domain from a URL & strip WWW
-function parseDomainFromUrl(url) {
-  var a = document.createElement('a');
-  a.href = url;
-  var m = a.hostname.match(DOMAIN_REGEX);
-  return m && m[0];
 }

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -82,9 +82,18 @@ function init(tab) {
   }
 
   activeTab = tab;
-  var parsedDomain = parseDomain(tab.url);
+  var parsedDomain = parseDomain(tab.url, {
+    customTlds:/localhost/,
+  });
+
   if( parsedDomain ) {
-    searchPassword(parsedDomain.domain + '.' + parsedDomain.tld);
+    var searchDomain = [parsedDomain.domain, parsedDomain.tld]
+      .filter(function (x) { return x; })
+      .join('.');
+
+    if( searchDomain ) {
+      searchPassword(searchDomain);
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "browserify": "^13.3.0",
-    "mithril": "^0.2.5"
+    "mithril": "^0.2.5",
+    "parse-domain": "^1.1.0"
   }
 }


### PR DESCRIPTION
* actually extract the matched domain name
* improve regex to match domains of TLDs that contain a dot (.co.uk)
* this most likely does not match *all* cases, but it is a simple and
  quick improvement that does not need a lot of logic or another
  dependency