### PR TITLE
Refactoring Go code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-browserpass
-browserpass-*
+/browserpass
+/browserpass-*
 *.crx
 *.log
 *.pem

--- a/browserpass_test.go
+++ b/browserpass_test.go
@@ -1,52 +1,21 @@
-package main
+package browserpass
 
 import (
-	"os"
+	"strings"
 	"testing"
 )
 
-func TestGetLogins(t *testing.T) {
-	domain := "this-most-definitely-does-not-exist"
-	logins := getLogins(domain)
-
-	if len(logins) > 0 {
-		t.Errorf("%s yielded results, but it should not", domain)
-	}
-}
-
-func TestGetPasswordStoreDir(t *testing.T) {
-	var home, expected, actual string
-	home = os.Getenv("HOME")
-
-	// default directory
-	os.Setenv("PASSWORD_STORE_DIR", "")
-	expected = home + "/.password-store"
-	actual, _ = getPasswordStoreDir()
-	if expected != actual {
-		t.Errorf("%s does not match %s", expected, actual)
-	}
-
-	// custom directory from $PASSWORD_STORE_DIR
-	expected = "/tmp/browserpass-test"
-	os.Mkdir(expected, os.ModePerm)
-	os.Setenv("PASSWORD_STORE_DIR", expected)
-	actual, _ = getPasswordStoreDir()
-	if expected != actual {
-		t.Errorf("%s does not match %s", expected, actual)
-	}
-
-	// clean-up
-	os.Remove(expected)
-}
-
 func TestParseLogin(t *testing.T) {
-	var b = []byte("password\n\nfoo\nlogin: bar")
-	login := parseLogin(b)
+	r := strings.NewReader("password\n\nfoo\nlogin: bar")
+
+	login, err := parseLogin(r)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if login.Password != "password" {
 		t.Errorf("Password is %s, expected %s", login.Password, "password")
 	}
-
 	if login.Username != "bar" {
 		t.Errorf("Username is %s, expected %s", login.Username, "bar")
 	}

--- a/cmd/browserpass/main.go
+++ b/cmd/browserpass/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/dannyvankooten/browserpass"
+	"github.com/dannyvankooten/browserpass/pass"
+)
+
+func main() {
+	log.SetPrefix("[Browserpass] ")
+
+	s, err := pass.NewDefaultStore()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := browserpass.Run(os.Stdin, os.Stdout, s); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/makefile
+++ b/makefile
@@ -22,11 +22,11 @@ static-files: chrome/host.json firefox/host.json
 	cp firefox/host.json firefox-host.json
 	cp chrome/policy.json chrome-policy.json
 
-browserpass-linux64: browserpass.go
-	env GOOS=linux GOARCH=amd64 go build -o $@
+browserpass-linux64: cmd/browserpass/main.go
+	env GOOS=linux GOARCH=amd64 go build -o $@ ./cmd/browserpass
 
-browserpass-darwinx64: browserpass.go
-	env GOOS=darwin GOARCH=amd64 go build -o $@
+browserpass-darwinx64: cmd/browserpass/main.go
+	env GOOS=darwin GOARCH=amd64 go build -o $@ ./cmd/browserpass
 
 .PHONY: static-files chrome firefox
 release: static-files chrome firefox browserpass-linux64 browserpass-darwinx64

--- a/pass/disk.go
+++ b/pass/disk.go
@@ -1,0 +1,73 @@
+package pass
+
+import (
+	"errors"
+	"io"
+	"path/filepath"
+	"os"
+	"strings"
+
+	"github.com/mattn/go-zglob"
+)
+
+type diskStore struct {
+	path string
+}
+
+func NewDefaultStore() (Store, error) {
+	path, err := defaultStorePath()
+	if err != nil {
+		return nil, err
+	}
+
+	return &diskStore{path}, nil
+}
+
+func defaultStorePath() (string, error) {
+	path := os.Getenv("PASSWORD_STORE_DIR")
+	if path == "" {
+		path = filepath.Join(os.Getenv("HOME"), ".password-store")
+	}
+
+	// Follow symlinks
+	return filepath.EvalSymlinks(path)
+}
+
+func (s *diskStore) Search(query string) ([]string, error) {
+	// First, search for DOMAIN/USERNAME.gpg
+	// Then, search for DOMAIN.gpg
+	matches, err := zglob.Glob(s.path + "/**/" + query + "*/*.gpg")
+	if err != nil {
+		return nil, err
+	}
+
+	matches2, err := zglob.Glob(s.path + "/**/" + query + "*.gpg")
+	if err != nil {
+		return nil, err
+	}
+
+	items := append(matches, matches2...)
+	for i, path := range items {
+		item, err := filepath.Rel(s.path, path)
+		if err != nil {
+			return nil, err
+		}
+		items[i] = strings.TrimSuffix(item, ".gpg")
+	}
+
+	return items, nil
+}
+
+func (s *diskStore) Open(item string) (io.ReadCloser, error) {
+	p := filepath.Join(s.path, item+".gpg")
+	if !filepath.HasPrefix(p, s.path) {
+		// Make sure the requested item is *in* the password store
+		return nil, errors.New("invalid item path")
+	}
+
+	f, err := os.Open(p)
+	if os.IsNotExist(err) {
+		return nil, ErrNotFound
+	}
+	return f, err
+}

--- a/pass/disk_test.go
+++ b/pass/disk_test.go
@@ -1,0 +1,48 @@
+package pass
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDefaultStorePath(t *testing.T) {
+	var home, expected, actual string
+	home = os.Getenv("HOME")
+
+	// default directory
+	os.Setenv("PASSWORD_STORE_DIR", "")
+	expected = home + "/.password-store"
+	actual, _ = defaultStorePath()
+	if expected != actual {
+		t.Errorf("%s does not match %s", expected, actual)
+	}
+
+	// custom directory from $PASSWORD_STORE_DIR
+	expected = "/tmp/browserpass-test"
+	os.Mkdir(expected, os.ModePerm)
+	os.Setenv("PASSWORD_STORE_DIR", expected)
+	actual, _ = defaultStorePath()
+	if expected != actual {
+		t.Errorf("%s does not match %s", expected, actual)
+	}
+
+	// clean-up
+	os.Setenv("PASSWORD_STORE_DIR", "")
+	os.Remove(expected)
+}
+
+func TestDiskStore_Search_nomatch(t *testing.T) {
+	s, err := NewDefaultStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	domain := "this-most-definitely-does-not-exist"
+	logins, err := s.Search(domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(logins) > 0 {
+		t.Errorf("%s yielded results, but it should not", domain)
+	}
+}

--- a/pass/pass.go
+++ b/pass/pass.go
@@ -1,0 +1,16 @@
+// Package pass provides access to UNIX password stores.
+package pass
+
+import (
+	"errors"
+	"io"
+)
+
+// ErrNotFound is returned by Store.Open if the requested item is not found.
+var ErrNotFound = errors.New("pass: not found")
+
+// Store is a password store.
+type Store interface {
+	Search(query string) ([]string, error)
+	Open(item string) (io.ReadCloser, error)
+}


### PR DESCRIPTION
- Adds a `pass` package with a `Store` interface - will allow new stores implementation (e.g. a Git store, see https://github.com/emersion/webpass/blob/master/config/auth_git.go#L122)
- Use streaming APIs instead of `[]byte`
- Use a `cmd/browserpass` package for `main` instead of putting it in the repo's root and not being able to split the code in multiple files
- Better testability (I just ported the old tests, but it should be easier to ad new ones)