### PR TITLE
#46 put password in all frames which contain visible password field

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -12,7 +12,9 @@
   },
   "permissions": [
     "activeTab",
-    "nativeMessaging"
+    "nativeMessaging",
+    "http://*/*",
+    "https://*/*"
   ],
   "commands": {
    "_execute_browser_action": {

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -149,12 +149,23 @@ function fillLoginForm(login) {
 
   var code = `
   (function(d) {
+    function queryFirstVisible(parent, selector) {
+      var elems = parent.querySelectorAll(selector);
+      for (var i=0; i < elems.length; i++) {
+        var style = window.getComputedStyle(elems[i]);
+        if (style.visibility !== 'hidden' && style.display !== 'none') {
+          return elems[i];
+        }
+      }
+    }
+
     function form() {
-      return d.querySelector('input[type=password]').form || document.createElement('form');
+      var passwordField = queryFirstVisible(d, 'input[type=password]');
+      return (passwordField && passwordField.form) ? passwordField.form : undefined;
     }
 
     function field(selector) {
-      return form().querySelector(selector) || document.createElement('input');
+      return queryFirstVisible(form(), selector) || document.createElement('input');
     }
 
     function update(el, value) {
@@ -172,6 +183,10 @@ function fillLoginForm(login) {
       return true;
     }
 
+    if (typeof form() === 'undefined') {
+      return;
+    }
+
     update(field('input[type=password]'), ${JSON.stringify(login.p)});
     update(field('input[type=email], input[type=text]'), ${JSON.stringify(login.u)});
 
@@ -183,6 +198,6 @@ function fillLoginForm(login) {
     }
   })(document);
   `;
-  chrome.tabs.executeScript({ code: code });
+  chrome.tabs.executeScript({ code: code, allFrames: true });
   window.close();
 }

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -149,7 +149,8 @@ function fillLoginForm(login) {
 
   var code = `
   (function(d) {
-    function queryFirstVisible(parent, selector) {
+    function queryAllVisible(parent, selector) {
+      var result = [];
       var elems = parent.querySelectorAll(selector);
       for (var i=0; i < elems.length; i++) {
         // Elem or its parent has a style 'display: none',
@@ -161,8 +162,14 @@ function fillLoginForm(login) {
         if (style.visibility == 'hidden') { continue; }
 
         // This element is visible, will use it.
-        return elems[i];
+        result.push(elems[i]);
       }
+      return result;
+    }
+
+    function queryFirstVisible(parent, selector) {
+      var elems = queryAllVisible(parent, selector);
+      return (elems.length > 0) ? elems[0] : undefined;
     }
 
     function form() {
@@ -196,7 +203,7 @@ function fillLoginForm(login) {
     update(field('input[type=password]'), ${JSON.stringify(login.p)});
     update(field('input[type=email], input[type=text]'), ${JSON.stringify(login.u)});
 
-    var password_inputs = document.querySelectorAll('input[type=password]');
+    var password_inputs = queryAllVisible(document, 'input[type=password]');
     if (password_inputs.length > 1) {
       password_inputs[1].select();
     } else {

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -152,10 +152,16 @@ function fillLoginForm(login) {
     function queryFirstVisible(parent, selector) {
       var elems = parent.querySelectorAll(selector);
       for (var i=0; i < elems.length; i++) {
+        // Elem or its parent has a style 'display: none',
+        // or it is just too narrow to be a real field (a trap for spammers?).
+        if (elems[i].offsetWidth < 50 || elems[i].offsetHeight < 10) { continue; }
+
         var style = window.getComputedStyle(elems[i]);
-        if (style.visibility !== 'hidden' && style.display !== 'none') {
-          return elems[i];
-        }
+        // Elem takes space on the screen, but it or its parent is hidden with a visibility style.
+        if (style.visibility == 'hidden') { continue; }
+
+        // This element is visible, will use it.
+        return elems[i];
       }
     }
 


### PR DESCRIPTION
This is a pretty naive approach to fix #46, where instead of pasting password in the top frame, the extension will try paste it in all available frames (this requires adding more permissions). 

To do as little as possible in the frames which don't have the password field, I added an early return. While testing I also discovered that some websites have frames with _hidden_ password fields - if user doesn't see them, these we want to exclude as well.

Like it was before, if a page has two visible password fields, we just pick the first one.