### PR TITLE
Wildcard passwords

### DIFF
--- a/pass/disk.go
+++ b/pass/disk.go
@@ -46,7 +46,16 @@ func (s *diskStore) Search(query string) ([]string, error) {
 		return nil, err
 	}
 
-	items := append(matches, matches2...)
+        hostParts := strings.Split(query, ".")
+        matches3 := []string{}
+        if( len(hostParts) > 2 ) {
+        matches3, err = zglob.Glob(s.path + "/**/*." + hostParts[1] + "." + hostParts[2] + "*.gpg")
+		if err != nil {
+			return nil, err
+		}
+        } 
+        
+	items := append(append(matches, matches2...), matches3...)
 	for i, path := range items {
 		item, err := filepath.Rel(s.path, path)
 		if err != nil {

--- a/pass/disk.go
+++ b/pass/disk.go
@@ -41,7 +41,7 @@ func (s *diskStore) Search(query string) ([]string, error) {
 		return nil, err
 	}
 
-	matches2, err := zglob.Glob(s.path + "/**/" + query + "*.gpg")
+	matches2, err := zglob.Glob(s.path + "/**/*" + query + "*.gpg")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
These changes will enable wildcard password files support. 
For example *.google.com will match "accounts.google.com", "photos.google.com", and so on...
Only one level of subdomains is supported so far: "photos.accounts.google.com" would not be matched.