### PR TITLE
Implement lookup separate from search

### DIFF
--- a/browserpass.go
+++ b/browserpass.go
@@ -56,6 +56,12 @@ func Run(stdin io.Reader, stdout io.Writer, s pass.Store) error {
 				return err
 			}
 			resp = list
+		case "lookup":
+			list, err := s.Lookup(data.Domain)
+			if err != nil {
+				return err
+			}
+			resp = list
 		case "get":
 			rc, err := s.Open(data.Entry)
 			if err != nil {

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -72,7 +72,7 @@ function submitSearchForm(e) {
       return;
   }
 
-  searchPassword(this.s.value);
+  searchPassword("search", this.s.value);
 }
 
 function init(tab) {
@@ -87,24 +87,23 @@ function init(tab) {
   });
 
   if( parsedDomain ) {
-    var searchDomain = [parsedDomain.domain, parsedDomain.tld]
-      .filter(function (x) { return x; })
-      .join('.');
+    var searchDomain = [parsedDomain.subdomain, parsedDomain.domain, parsedDomain.tld]
+      .filter(function (x) { return x != "" }).join(".")
 
     if( searchDomain ) {
-      searchPassword(searchDomain);
+      searchPassword("lookup", searchDomain);
     }
   }
 }
 
-function searchPassword(_domain) {
+function searchPassword(_action, _domain) {
   searching = true;
   logins = null;
   domain = _domain;
   urlDuringSearch = activeTab.url;
   m.redraw();
 
-  chrome.runtime.sendNativeMessage(app, { "action": "search", "domain": _domain }, function(response) {
+  chrome.runtime.sendNativeMessage(app, { "action": _action, "domain": _domain }, function(response) {
     if( chrome.runtime.lastError ) {
       console.log(chrome.runtime.lastError);
     }

--- a/pass/disk.go
+++ b/pass/disk.go
@@ -3,11 +3,15 @@ package pass
 import (
 	"errors"
 	"io"
-	"path/filepath"
+	"io/ioutil"
 	"os"
+	"path"
+	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/mattn/go-zglob"
+	"github.com/mattn/go-zglob/fastwalk"
 )
 
 type diskStore struct {
@@ -31,6 +35,107 @@ func defaultStorePath() (string, error) {
 
 	// Follow symlinks
 	return filepath.EvalSymlinks(path)
+}
+
+func lookup(domain string, sites []*site) []*site {
+	results := make([]*site, 0)
+	domainParts := reverse(strings.Split(domain, "."))
+	for _, s := range sites {
+		parts := reverse(strings.Split(s.domain, "."))
+		if subMatch(domainParts, parts, 2) {
+			results = append(results, s)
+		}
+	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return len(results[i].domain) > len(results[j].domain)
+	})
+
+	return results
+}
+
+func reverse(strings []string) []string {
+	for i, j := 0, len(strings)-1; i < j; i, j = i+1, j-1 {
+		strings[i], strings[j] = strings[j], strings[i]
+	}
+
+	return strings
+}
+
+func subMatch(x, y []string, min int) bool {
+	if len(y) < min {
+		return false
+	}
+
+	if len(x) < len(y) {
+		return false
+	}
+
+	matches := 0
+	for i := len(y) - 1; i > -1; i-- {
+		if y[i] == x[i] {
+			matches++
+		} else {
+			return false
+		}
+
+		if matches >= min {
+			return true
+		}
+	}
+
+	return false
+}
+
+type site struct {
+	domain string
+	users  []string
+}
+
+func (s *diskStore) Lookup(query string) ([]string, error) {
+	sites := make([]*site, 0)
+	siteCh := make(chan *site)
+	go func() {
+		for site := range siteCh {
+			sites = append(sites, site)
+		}
+	}()
+
+	err := fastwalk.FastWalk(s.path, func(dir string, typ os.FileMode) error {
+		if dir == s.path {
+			return nil
+		}
+		if typ&os.ModeDir != 0 {
+			files, err := ioutil.ReadDir(dir)
+			if err != nil {
+				return err
+			}
+
+			users := make([]string, 0, len(files))
+			for _, file := range files {
+				users = append(users, strings.TrimSuffix(file.Name(), ".gpg"))
+			}
+			siteCh <- &site{domain: path.Base(dir), users: users}
+			return filepath.SkipDir
+		}
+
+		return nil
+	})
+	close(siteCh)
+	if err != nil {
+		return nil, err
+	}
+
+	sites = lookup(query, sites)
+
+	results := make([]string, 0, len(sites))
+	for _, site := range sites {
+		for _, user := range site.users {
+			results = append(results, site.domain+"/"+user)
+		}
+	}
+
+	return results, nil
 }
 
 func (s *diskStore) Search(query string) ([]string, error) {

--- a/pass/disk.go
+++ b/pass/disk.go
@@ -37,6 +37,7 @@ func defaultStorePath() (string, error) {
 	return filepath.EvalSymlinks(path)
 }
 
+// lookup will find sites matching or partly matching the passed domain.
 func lookup(domain string, sites []*site) []*site {
 	results := make([]*site, 0)
 	domainParts := reverse(strings.Split(domain, "."))
@@ -47,6 +48,7 @@ func lookup(domain string, sites []*site) []*site {
 		}
 	}
 
+	// sort by length of domain, longest first.
 	sort.Slice(results, func(i, j int) bool {
 		return len(results[i].domain) > len(results[j].domain)
 	})
@@ -54,6 +56,7 @@ func lookup(domain string, sites []*site) []*site {
 	return results
 }
 
+// reverse reverses the element order of a string slice.
 func reverse(strings []string) []string {
 	for i, j := 0, len(strings)-1; i < j; i, j = i+1, j-1 {
 		strings[i], strings[j] = strings[j], strings[i]
@@ -62,18 +65,26 @@ func reverse(strings []string) []string {
 	return strings
 }
 
-func subMatch(x, y []string, min int) bool {
-	if len(y) < min {
+// subMatch validates whether the candidate string slice matches at least min
+// parts of the query slice.
+// Example:
+//    query = ["org", "example", "my"]
+//    candidate = ["org", "example"]
+//    min = 2
+// this will match because both elements of candidate is found in the same
+// order in query.
+func subMatch(query, candidate []string, min int) bool {
+	if len(candidate) < min {
 		return false
 	}
 
-	if len(x) < len(y) {
+	if len(query) < len(candidate) {
 		return false
 	}
 
 	matches := 0
-	for i := len(y) - 1; i > -1; i-- {
-		if y[i] == x[i] {
+	for i := len(candidate) - 1; i > -1; i-- {
+		if candidate[i] == query[i] {
 			matches++
 		} else {
 			return false
@@ -87,17 +98,27 @@ func subMatch(x, y []string, min int) bool {
 	return false
 }
 
+// site defines a domain and the related users stored for this domain.
 type site struct {
 	domain string
 	users  []string
 }
 
-func (s *diskStore) Lookup(query string) ([]string, error) {
+// Lookup looks up domains in the password store based on the domainQuery string.
+// the lookup will return a list of domains/subdomains matching the query with
+// the most precise domain first.
+// Assuming the domains "sub1.domain.tld", "sub2.domain.tld" and "domain.tld"
+// are defined in the store, and the query domain is "sub1.domain.tld" the
+// lookup will return the list ["sub1.domain.tld", "domain.tld"]. If
+// "domain.tld" is the query domain then only ["domain.tld"] will be returned
+// as the matching is done from front to end thus not matching the subdoamins.
+func (s *diskStore) Lookup(domainQuery string) ([]string, error) {
 	sites := make([]*site, 0)
 	siteCh := make(chan *site)
 	errCh := make(chan error)
 
 	go func() {
+		// use FastWalk to collect all domains/users defined in the password store.
 		err := fastwalk.FastWalk(s.path, func(dir string, typ os.FileMode) error {
 			if dir == s.path {
 				return nil
@@ -130,7 +151,7 @@ func (s *diskStore) Lookup(query string) ([]string, error) {
 		return nil, err
 	}
 
-	sites = lookup(query, sites)
+	sites = lookup(domainQuery, sites)
 
 	results := make([]string, 0, len(sites))
 	for _, site := range sites {

--- a/pass/disk_test.go
+++ b/pass/disk_test.go
@@ -1,9 +1,54 @@
 package pass
 
 import (
+	"fmt"
 	"os"
+	"path"
 	"testing"
+	"time"
 )
+
+type domainUser struct {
+	domain, user string
+}
+
+func setupTestStore(t *testing.T) string {
+	storeDir := path.Join(os.TempDir(), fmt.Sprintf("browserpass-%d", time.Now().UTC().UnixNano()))
+
+	domains := []*domainUser{
+		{"foo.bar", "u1.gpg"},
+		{"foo.bar", "u2.gpg"},
+		{"baz.foo.bar", "u1.gpg"},
+		{"domain.tld", "u1.gpg"},
+		{"sub.domain.tld", "u1.gpg"},
+		{"sub.sub.domain.tld", "u1.gpg"},
+	}
+
+	for _, du := range domains {
+		err := os.MkdirAll(path.Join(storeDir, du.domain), os.ModePerm)
+		if err != nil {
+			t.Errorf("should not fail: %s", err)
+		}
+
+		f, err := os.Create(path.Join(storeDir, du.domain, du.user))
+		if err != nil {
+			t.Errorf("should not fail: %s", err)
+		}
+		err = f.Close()
+		if err != nil {
+			t.Errorf("should not fail: %s", err)
+		}
+	}
+
+	return storeDir
+}
+
+func cleanTestStore(t *testing.T, storeDir string) {
+	err := os.RemoveAll(storeDir)
+	if err != nil {
+		t.Errorf("should not fail: %s", err)
+	}
+}
 
 func TestDefaultStorePath(t *testing.T) {
 	var home, expected, actual string
@@ -32,6 +77,10 @@ func TestDefaultStorePath(t *testing.T) {
 }
 
 func TestDiskStore_Search_nomatch(t *testing.T) {
+	storeDir := setupTestStore(t)
+	defer cleanTestStore(t, storeDir)
+
+	os.Setenv("PASSWORD_STORE_DIR", storeDir)
 	s, err := NewDefaultStore()
 	if err != nil {
 		t.Fatal(err)
@@ -44,5 +93,77 @@ func TestDiskStore_Search_nomatch(t *testing.T) {
 	}
 	if len(logins) > 0 {
 		t.Errorf("%s yielded results, but it should not", domain)
+	}
+}
+
+func TestDiskStoreLookup(t *testing.T) {
+	storeDir := setupTestStore(t)
+	defer cleanTestStore(t, storeDir)
+
+	// TODO fix
+	os.Setenv("PASSWORD_STORE_DIR", storeDir)
+
+	s, err := NewDefaultStore()
+	if err != nil {
+		t.Error(err)
+	}
+
+	for _, tc := range []struct {
+		msg      string
+		domain   string
+		expected []string
+	}{
+		{
+			msg:      "should find sub.domain.tld followed by domain.tld",
+			domain:   "sub.domain.tld",
+			expected: []string{"sub.domain.tld/u1", "domain.tld/u1"},
+		},
+		{
+			msg:      "should find sub.sub.domain.tld, sub.domain.tld followed by domain.tld",
+			domain:   "sub.sub.domain.tld",
+			expected: []string{"sub.sub.domain.tld/u1", "sub.domain.tld/u1", "domain.tld/u1"},
+		},
+		{
+			msg:      "should find two users for foo.bar",
+			domain:   "foo.bar",
+			expected: []string{"foo.bar/u1", "foo.bar/u2"},
+		},
+	} {
+		t.Run(tc.msg, func(t *testing.T) {
+			logins, err := s.Lookup(tc.domain)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if len(logins) != len(tc.expected) {
+				t.Errorf("expected %d results, got %d", len(tc.expected), len(logins))
+			}
+
+			for i, l := range logins {
+				if l != tc.expected[i] {
+					t.Errorf("expected %s, got %s", tc.expected[i], l)
+				}
+			}
+		})
+	}
+}
+
+func TestLookup(t *testing.T) {
+	sites := []*site{
+		{domain: "example.org", users: nil},
+		{domain: "my.example.org", users: nil},
+		{domain: "other.example.org", users: nil},
+		{domain: "google.com", users: nil},
+	}
+
+	domain := "my.example.org"
+
+	sitesFound := lookup(domain, sites)
+	if len(sitesFound) != 2 {
+		t.Fatalf("expected 2 sites matching, found %d", len(sitesFound))
+	}
+
+	if sitesFound[0].domain != domain {
+		t.Fatalf("expected first domain to be '%s', got '%s'", domain, sitesFound[0].domain)
 	}
 }

--- a/pass/pass.go
+++ b/pass/pass.go
@@ -12,5 +12,6 @@ var ErrNotFound = errors.New("pass: not found")
 // Store is a password store.
 type Store interface {
 	Search(query string) ([]string, error)
+	Lookup(query string) ([]string, error)
 	Open(item string) (io.ReadCloser, error)
 }


### PR DESCRIPTION
As discussed in #44 I think it makes sense to split the behavior of the search field and the list of domains shown in browserpass.

This is my PoC for separating search and lookup.

The algorithm used for lookup is a follows:

Assuming you have the following domains in your store:

```
my.sub1.domain.tld
sub1.domain.tld
sub2.domain.tld
domain.tld
sub1.domain2.tld
domain2.tld
```

and you are on page `sub1.domain.tld`, then the lookup will return the following list of domains `[sub1.domain.tld, domain.tld]` ordered by most precise match.

As this is a PoC not everything is implemented yet:

* [ ] handle domains stored as `domain.tld.gpg` (currently only handles `domain.tld/user.gpg`).
* [ ] handle multilevel tlds correctly e.g. `co.uk`.
* [ ] consider stripping `www.` automatically.

I also haven't benchmarked the implementation, but I suspect it's on par with the current zglob implementation.


I realize this is somewhat conflicting with #61 and I'm fine with you going that way if you prefer.