### PR TITLE
fix several compatibility issues with windows

### DIFF
--- a/browserpass.go
+++ b/browserpass.go
@@ -95,8 +95,8 @@ func readLoginGPG(r io.Reader) (*Login, error) {
 	opts := []string{"--decrypt", "--yes", "--quiet"}
 
 	// Check if gpg2 is available
-	which := exec.Command("which", "gpg2")
-	if err := which.Run(); err == nil {
+	gpg2check := exec.Command("gpg2", "--version")
+	if err := gpg2check.Run(); err == nil {
 		gpgbin = "gpg2"
 		opts = append(opts, "--use-agent", "--batch")
 	}

--- a/pass/disk.go
+++ b/pass/disk.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/mattn/go-zglob"
+	"os/user"
 )
 
 type diskStore struct {
@@ -24,9 +25,15 @@ func NewDefaultStore() (Store, error) {
 }
 
 func defaultStorePath() (string, error) {
+	usr, err := user.Current()
+
+	if err != nil {
+		return "", err
+	}
+
 	path := os.Getenv("PASSWORD_STORE_DIR")
 	if path == "" {
-		path = filepath.Join(os.Getenv("HOME"), ".password-store")
+		path = filepath.Join(usr.HomeDir, ".password-store")
 	}
 
 	// Follow symlinks

--- a/pass/disk_test.go
+++ b/pass/disk_test.go
@@ -3,22 +3,37 @@ package pass
 import (
 	"os"
 	"testing"
+	"os/user"
+	"path/filepath"
+	"fmt"
 )
 
 func TestDefaultStorePath(t *testing.T) {
 	var home, expected, actual string
-	home = os.Getenv("HOME")
+
+	usr, err := user.Current()
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	home = usr.HomeDir
 
 	// default directory
 	os.Setenv("PASSWORD_STORE_DIR", "")
-	expected = home + "/.password-store"
+	expected = filepath.Join(home, ".password-store")
 	actual, _ = defaultStorePath()
 	if expected != actual {
 		t.Errorf("%s does not match %s", expected, actual)
 	}
 
 	// custom directory from $PASSWORD_STORE_DIR
-	expected = "/tmp/browserpass-test"
+	expected, err = filepath.Abs("browserpass-test")
+	if err != nil {
+		t.Error(err)
+	}
+
+	fmt.Println(expected)
 	os.Mkdir(expected, os.ModePerm)
 	os.Setenv("PASSWORD_STORE_DIR", expected)
 	actual, _ = defaultStorePath()


### PR DESCRIPTION
modify disk.go to use the go builtin os/user package instead of relying on $HOME and modify disk_test.go accordingly
change check for gpg2 from "which gpg2" (not available on windows) to "gpg2 --version"