### PR TITLE
Fix 'type=email' not available by using 'name=email'.

### DIFF
--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -173,7 +173,7 @@ function fillLoginForm(login) {
     }
 
     update(field('input[type=password]'), ${JSON.stringify(login.p)});
-    update(field('input[type=email], input[type=text]'), ${JSON.stringify(login.u)});
+    update(field('input[type=email], input[type=text], input[name=email]'), ${JSON.stringify(login.u)});
 
     var password_inputs = document.querySelectorAll('input[type=password]');
     if (password_inputs.length > 1) {


### PR DESCRIPTION
Some websites, e.g. Netflix (https://www.netflix.com/de-en/login) doesn't use `type='email'` or `type='text'` for the username field. Instead the field can/must be identified by using `name='email'`.