### PR TITLE
Check for 2nd password field only in the same form.

### DIFF
--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -175,7 +175,7 @@ function fillLoginForm(login) {
     update(field('input[type=password]'), ${JSON.stringify(login.p)});
     update(field('input[type=email], input[type=text]'), ${JSON.stringify(login.u)});
 
-    var password_inputs = document.querySelectorAll('input[type=password]');
+    var password_inputs = form().querySelectorAll('input[type=password]');
     if (password_inputs.length > 1) {
       password_inputs[1].select();
     } else {


### PR DESCRIPTION
With https://github.com/dannyvankooten/browserpass/pull/31 the second field with `type=password` is always selected, also if it isn't part of the login form but rather of the registration form, e.g. https://twitter.com/.

By changing document to form(), only in the chosen login form a search for a second `type=password` is done and other services continue to login.
Of course this doesn't break the domain given in https://github.com/dannyvankooten/browserpass/issues/27#issuecomment-271384644.