### PR TITLE
form() now only returns the first visible element.

### DIFF
--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -150,7 +150,10 @@ function fillLoginForm(login) {
   var code = `
   (function(d) {
     function form() {
-      return d.querySelector('input[type=password]').form || document.createElement('form');
+      var elems = d.querySelectorAll('input[type=password]');
+      for (var el of elems)
+        if (el.form.offsetParent !== null) return el.form;
+      return document.createElement('form');
     }
 
     function field(selector) {


### PR DESCRIPTION
When calling `form()`, the first form is given also if it isn't visible for the user (hidden forms).
With this PR, all forms which contain a `input[type=password]` are searched - again returning the first element - but only if it is visible.

For test, e.g. https://twitter.com/

Edit: https://github.com/dannyvankooten/browserpass/pull/55 already contains a better patch for the same problem.