### PR TITLE
Completion for password only input

### DIFF
--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -200,8 +200,9 @@ function fillLoginForm(login) {
       return;
     }
 
-    update(field('input[type=password]'), ${JSON.stringify(login.p)});
+    // Order must be : login than password, so that password only page can be completed
     update(field('input[type=email], input[type=text], input:first-of-type'), ${JSON.stringify(login.u)});
+    update(field('input[type=password]'), ${JSON.stringify(login.p)});
 
     var password_inputs = queryAllVisible(form(), 'input[type=password]');
     if (password_inputs.length > 1) {


### PR DESCRIPTION
With the actual behavior if the page only has a password input (password confirmation page...) then it will be filled and overridden by the login afterwards because it's the first of type input. If we change the order than it will correctly work.
I added a comment so that this behavior will not be lost overtime which can easily happened with this kind of details.