### PR TITLE
Added subdomain part to domain search, fixes #81

### DIFF
--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -87,7 +87,7 @@ function init(tab) {
   });
 
   if( parsedDomain ) {
-    var searchDomain = [parsedDomain.domain, parsedDomain.tld]
+    var searchDomain = [parsedDomain.subdomain, parsedDomain.domain, parsedDomain.tld]
       .filter(function (x) { return x; })
       .join('.');
 


### PR DESCRIPTION
With the parse-domain library the domain gets split up into three parts, subdomain, domain, tld. The implementation combined the domain and tld part but ommitted the subdomain part. Therefore a search for `test.example.com` would only return domains containing `example.com` and omitting everything else.