### PR TITLE
Add options page to enable/disable auto-submit for filled forms

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -7,7 +7,7 @@ chrome.runtime.onMessage.addListener(onMessage);
 // fill login form & submit
 function fillLoginForm(login) {
   chrome.tabs.executeScript(
-    { code: "var login = " + JSON.stringify(login) + ";" },
+    { code: "var login = " + JSON.stringify(login) + "; var autoSubmit = " + JSON.stringify(localStorage.getItem("autoSubmit")) + ";"},
     function() {
       chrome.tabs.executeScript({ file: "/inject.js", allFrames: true });
     }

--- a/chrome/inject.browserify.js
+++ b/chrome/inject.browserify.js
@@ -78,7 +78,7 @@
   );
 
   var password_inputs = queryAllVisible(form(), "input[type=password]");
-  if (password_inputs.length > 1) {
+  if (autoSubmit == 'false' || password_inputs.length > 1) {
     password_inputs[1].select();
   } else {
     window.requestAnimationFrame(function() {

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -12,6 +12,12 @@
       "background.js"
     ]
   },
+  "options_page": "options.html",
+  "options_ui": {
+    "page": "options.html",
+    "chrome_style": true,
+    "open_in_tab": false
+  },
   "browser_action": {
     "default_icon": "icon-lock.png",
     "default_popup": "content.html"
@@ -19,6 +25,7 @@
   "permissions": [
     "activeTab",
     "nativeMessaging",
+    "storage",
     "http://*/*",
     "https://*/*"
   ],

--- a/chrome/options.html
+++ b/chrome/options.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Browserpass Chrome extension for zx2c4's pass (password manager)</title>
+  <style>
+    body: { padding: 10px; }
+  </style>
+</head>
+<body>
+
+<label>
+  <input type="checkbox" id="auto-submit">
+  Auto-Submit login forms
+</label>
+<br/>
+<br/>
+<button id="save">Save</button>
+
+<script src="options.js"></script>
+</body>
+</html>

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -1,6 +1,7 @@
 function save_options() {
   var autoSubmit = document.getElementById('auto-submit').checked;
   localStorage.setItem('autoSubmit', autoSubmit);
+  window.close();
 }
 
 function restore_options() {

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -1,0 +1,18 @@
+function save_options() {
+  var autoSubmit = document.getElementById('auto-submit').checked;
+  localStorage.setItem('autoSubmit', autoSubmit);
+}
+
+function restore_options() {
+  var autoSubmit = localStorage.getItem('autoSubmit');
+  if (autoSubmit == 'false') {
+    autoSubmit = false;
+  } else {
+    // Load the default
+    autoSubmit = true;
+  }
+  document.getElementById('auto-submit').checked = autoSubmit;
+}
+
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click', save_options);

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -5,6 +5,9 @@
   "version": "1.0.7",
   "author": "Danny van Kooten",
   "homepage_url": "https://github.com/dannyvankooten/browserpass",
+  "options_ui": {
+    "page": "options.html",
+  },
   "browser_action": {
     "browser_style": false,
     "default_icon": "icon-lock.png",
@@ -12,7 +15,8 @@
   },
   "permissions": [
     "activeTab",
-    "nativeMessaging"
+    "nativeMessaging",
+    "storage"
   ],
   "commands": {
     "_execute_browser_action": {


### PR DESCRIPTION
I've added a very(!) simple options page to support disabling of auto-submit for forms.

Maybe someone can do some testing with firefox as I'm not sure if this is working cross browser (albeit I've used `localStorage` in favor of the, I guess, browser specific `storage` or `chrome.storage` APIs).

fixes #94 
