### PR TITLE
Fix username bug on windows

### DIFF
--- a/browserpass.go
+++ b/browserpass.go
@@ -159,7 +159,7 @@ func parseLogin(r io.Reader) (*Login, error) {
 
 // guessLogin tries to guess a username from an entry's name.
 func guessUsername(name string) string {
-	if strings.Count(name, "/") >= 1 {
+	if strings.Count(filepath.ToSlash(name), "/") >= 1 {
 		return filepath.Base(name)
 	}
 	return ""


### PR DESCRIPTION
On windows, browserpass wouldn't detect the username automatically
from the password entry name. This was due to the fact that windows
uses backslashes (\) as path seperators, while Linux (read: everybody
else in the entire world) uses forward slashes (/)

This fixes the guessUsername function to always convert the path to be
slash-delimited.

Fixes #130 