### PR TITLE
add support for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Start out by downloading the [latest release package](https://github.com/dannyva
 #### Installing the host application
 
 1. Extract the package to where you would like to have the binary.
-1. Run `./install.sh` (`.\install.ps1` on Windows) to install the native messaging host. If you want a system-wide installation, run the script with `sudo`. For Windows, system-wide installation can be done by running `.\install.ps1 global` as Administrator.
+1. Run `./install.sh` (`.\install.ps1` on Windows) to install the native messaging host. If you want a system-wide installation, run the script with `sudo`. For Windows, system-wide installation can be done by running `.\install.ps1` as Administrator and specifying "yes" at the "Install for all users?" prompt.
 
 Installing the binary & registering it with your browser through the installation script is required to allow the browser extension to talk to the local binary application.
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ login: johndoe
 
 ## Installation
 
-Start out by downloading the [latest release package](https://github.com/dannyvankooten/browserpass/releases) for your operating system. Prebuilt binaries for 64-bit OSX & Linux are available. Arch users can install browserpass [from the AUR](https://aur.archlinux.org/packages/browserpass/).
+Start out by downloading the [latest release package](https://github.com/dannyvankooten/browserpass/releases) for your operating system. Prebuilt binaries for 64-bit OSX & Linux and Windows are available. Arch users can install browserpass [from the AUR](https://aur.archlinux.org/packages/browserpass/).
 
 #### Installing the host application
 
 1. Extract the package to where you would like to have the binary.
-1. Run `./install.sh` to install the native messaging host. If you want a system-wide installation, run the script with `sudo`.
+1. Run `./install.sh` (`.\install.ps1` on Windows) to install the native messaging host. If you want a system-wide installation, run the script with `sudo`. For Windows, system-wide installation can be done by running `.\install.ps1 global` as Administrator.
 
 Installing the binary & registering it with your browser through the installation script is required to allow the browser extension to talk to the local binary application.
 

--- a/install.ps1
+++ b/install.ps1
@@ -20,11 +20,23 @@ $ffile -replace '%%replace%%', ((Join-Path -Path $dirpath -ChildPath 'browserpas
 $cfile = gc chrome-host.json
 $cfile -replace '%%replace%%', ((Join-Path -Path $dirpath -ChildPath 'browserpass-windows64.exe' | ConvertTo-json) -replace '^"|"$', "") | Out-File -Encoding UTF8 $chrome_jsonpath
 
-# Add oour registry values fore ff
-New-Item -Path "hkcu:\Software\Mozilla\NativeMessagingHosts\$app" -force
-New-ItemProperty -Path "hkcu:\Software\Mozilla\NativeMessagingHosts\$app" -Name '(Default)' -Value $ff_jsonpath -force
+if ($args[0] -eq "global") {
+	Write-Host "Installing browserpass for all users"
+	# add our registry values for all users
+	New-Item -Path "hklm:\Software\Mozilla\NativeMessagingHosts" -force
+	New-Item -Path "hklm:\Software\Mozilla\NativeMessagingHosts\$app" -force
+	New-ItemProperty -Path "hklm:\Software\Mozilla\NativeMessagingHosts\$app" -Name '(Default)' -Value $ff_jsonpath -force
 
-# Add oour registry values fore chrome
-New-Item -Path "hkcu:\Software\Google\Chrome\NativeMessagingHosts\$app" -force
-New-ItemProperty -Path "hkcu:\Software\Google\Chrome\NativeMessagingHosts\$app" -Name '(Default)' -Value $chrome_jsonpath -force
+	#New-Item -Path "hklm:\Software\Google\Chrome\NativeMessagingHosts" -force
+	New-Item -Path "hklm:\Software\Google\Chrome\NativeMessagingHosts\$app" -force
+	New-ItemProperty -Path "hklm:\Software\Google\Chrome\NativeMessagingHosts\$app" -Name '(Default)' -Value $chrome_jsonpath -force
+} else {
+	Write-Host "Installing browserpass for current user"
+	# add our registry values for current users
+	New-Item -Path "hkcu:\Software\Mozilla\NativeMessagingHosts\$app" -force
+	New-ItemProperty -Path "hkcu:\Software\Mozilla\NativeMessagingHosts\$app" -Name '(Default)' -Value $ff_jsonpath -force
+
+	New-Item -Path "hkcu:\Software\Google\Chrome\NativeMessagingHosts\$app" -force
+	New-ItemProperty -Path "hkcu:\Software\Google\Chrome\NativeMessagingHosts\$app" -Name '(Default)' -Value $chrome_jsonpath -force
+}
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,30 @@
+# Installs the native manifest on windows
+# 
+
+$app = 'com.dannyvankooten.browserpass'
+
+$dirpath = Join-Path -Path $env:localappdata -ChildPath 'browserpass'
+$ff_jsonpath = Join-Path -Path $dirpath -ChildPath "$app-firefox.json"
+$chrome_jsonpath = Join-Path -Path $dirpath -ChildPath "$app-chrome.json"
+
+# Make our local directory
+new-item -type Directory -Path $dirpath -force
+
+# copy our bin to local directory
+& cp browserpass-windows64.exe $dirpath
+
+# copy the native messaging manifest
+$ffile = gc firefox-host.json
+$ffile -replace '%%replace%%', ((Join-Path -Path $dirpath -ChildPath 'browserpass-windows64.exe' | ConvertTo-json) -replace '^"|"$', "") | Out-File -Encoding UTF8 $ff_jsonpath
+
+$cfile = gc chrome-host.json
+$cfile -replace '%%replace%%', ((Join-Path -Path $dirpath -ChildPath 'browserpass-windows64.exe' | ConvertTo-json) -replace '^"|"$', "") | Out-File -Encoding UTF8 $chrome_jsonpath
+
+# Add oour registry values fore ff
+New-Item -Path "hkcu:\Software\Mozilla\NativeMessagingHosts\$app" -force
+New-ItemProperty -Path "hkcu:\Software\Mozilla\NativeMessagingHosts\$app" -Name '(Default)' -Value $ff_jsonpath -force
+
+# Add oour registry values fore chrome
+New-Item -Path "hkcu:\Software\Google\Chrome\NativeMessagingHosts\$app" -force
+New-ItemProperty -Path "hkcu:\Software\Google\Chrome\NativeMessagingHosts\$app" -Name '(Default)' -Value $chrome_jsonpath -force
+

--- a/install.ps1
+++ b/install.ps1
@@ -21,22 +21,23 @@ $cfile = gc chrome-host.json
 $cfile -replace '%%replace%%', ((Join-Path -Path $dirpath -ChildPath 'browserpass-windows64.exe' | ConvertTo-json) -replace '^"|"$', "") | Out-File -Encoding UTF8 $chrome_jsonpath
 
 if ($args[0] -eq "global") {
-	Write-Host "Installing browserpass for all users"
-	# add our registry values for all users
-	New-Item -Path "hklm:\Software\Mozilla\NativeMessagingHosts" -force
-	New-Item -Path "hklm:\Software\Mozilla\NativeMessagingHosts\$app" -force
-	New-ItemProperty -Path "hklm:\Software\Mozilla\NativeMessagingHosts\$app" -Name '(Default)' -Value $ff_jsonpath -force
+    Write-Host "Installing browserpass for all users"
+    # add our registry values for all users
+    New-Item -Path "hklm:\Software\Mozilla\NativeMessagingHosts" -force
+    New-Item -Path "hklm:\Software\Mozilla\NativeMessagingHosts\$app" -force
+    New-ItemProperty -Path "hklm:\Software\Mozilla\NativeMessagingHosts\$app" -Name '(Default)' -Value $ff_jsonpath -force
 
-	#New-Item -Path "hklm:\Software\Google\Chrome\NativeMessagingHosts" -force
-	New-Item -Path "hklm:\Software\Google\Chrome\NativeMessagingHosts\$app" -force
-	New-ItemProperty -Path "hklm:\Software\Google\Chrome\NativeMessagingHosts\$app" -Name '(Default)' -Value $chrome_jsonpath -force
-} else {
-	Write-Host "Installing browserpass for current user"
-	# add our registry values for current users
-	New-Item -Path "hkcu:\Software\Mozilla\NativeMessagingHosts\$app" -force
-	New-ItemProperty -Path "hkcu:\Software\Mozilla\NativeMessagingHosts\$app" -Name '(Default)' -Value $ff_jsonpath -force
+    #New-Item -Path "hklm:\Software\Google\Chrome\NativeMessagingHosts" -force
+    New-Item -Path "hklm:\Software\Google\Chrome\NativeMessagingHosts\$app" -force
+    New-ItemProperty -Path "hklm:\Software\Google\Chrome\NativeMessagingHosts\$app" -Name '(Default)' -Value $chrome_jsonpath -force
+}
+else {
+    Write-Host "Installing browserpass for current user"
+    # add our registry values for current users
+    New-Item -Path "hkcu:\Software\Mozilla\NativeMessagingHosts\$app" -force
+    New-ItemProperty -Path "hkcu:\Software\Mozilla\NativeMessagingHosts\$app" -Name '(Default)' -Value $ff_jsonpath -force
 
-	New-Item -Path "hkcu:\Software\Google\Chrome\NativeMessagingHosts\$app" -force
-	New-ItemProperty -Path "hkcu:\Software\Google\Chrome\NativeMessagingHosts\$app" -Name '(Default)' -Value $chrome_jsonpath -force
+    New-Item -Path "hkcu:\Software\Google\Chrome\NativeMessagingHosts\$app" -force
+    New-ItemProperty -Path "hkcu:\Software\Google\Chrome\NativeMessagingHosts\$app" -Name '(Default)' -Value $chrome_jsonpath -force
 }
 

--- a/makefile
+++ b/makefile
@@ -41,6 +41,9 @@ browserpass: cmd/browserpass/ pass/ browserpass.go
 browserpass-linux64: cmd/browserpass/ pass/ browserpass.go
 	env GOOS=linux GOARCH=amd64 go build -o $@ ./cmd/browserpass
 
+browserpass-windows64: cmd/browserpass/ pass/ browserpass.go
+	env GOOS=windows GOARCH=amd64 go build -o $@.exe ./cmd/browserpass
+
 browserpass-darwinx64: cmd/browserpass/ pass/ browserpass.go
 	env GOOS=darwin GOARCH=amd64 go build -o $@ ./cmd/browserpass
 
@@ -51,7 +54,7 @@ browserpass-freebsd64: cmd/browserpass/ pass/ browserpass.go
 	env GOOS=freebsd GOARCH=amd64 go build -o $@ ./cmd/browserpass
 
 .PHONY: static-files chrome firefox
-release: static-files chrome firefox browserpass-linux64 browserpass-darwinx64 browserpass-openbsd64 browserpass-freebsd64
+release: static-files chrome firefox browserpass-linux64 browserpass-darwinx64 browserpass-openbsd64 browserpass-freebsd64 browserpass-windows64
 	mkdir -p release
 	zip -jFS "release/chrome" chrome/* chrome-browserpass.crx
 	zip -jFS "release/firefox" firefox/*
@@ -59,3 +62,4 @@ release: static-files chrome firefox browserpass-linux64 browserpass-darwinx64 b
 	zip -FS "release/browserpass-darwinx64" browserpass-darwinx64 *-host.json chrome-browserpass.crx install.sh README.md LICENSE
 	zip -FS "release/browserpass-openbsd64" browserpass-openbsd64 *-host.json chrome-browserpass.crx install.sh README.md LICENSE
 	zip -FS "release/browserpass-freebsd64" browserpass-freebsd64 *-host.json chrome-browserpass.crx install.sh README.md LICENSE
+	zip -FS "release/browserpass-windows64" browserpass-windows64.exe *-host.json chrome-browserpass.crx install.ps1 README.md LICENSE

--- a/makefile
+++ b/makefile
@@ -62,4 +62,4 @@ release: static-files chrome firefox browserpass-linux64 browserpass-darwinx64 b
 	zip -FS "release/browserpass-darwinx64" browserpass-darwinx64 *-host.json chrome-browserpass.crx install.sh README.md LICENSE
 	zip -FS "release/browserpass-openbsd64" browserpass-openbsd64 *-host.json chrome-browserpass.crx install.sh README.md LICENSE
 	zip -FS "release/browserpass-freebsd64" browserpass-freebsd64 *-host.json chrome-browserpass.crx install.sh README.md LICENSE
-	zip -FS "release/browserpass-windows64" browserpass-windows64.exe *-host.json chrome-browserpass.crx install.ps1 README.md LICENSE
+	zip -FS "release/browserpass-windows64" browserpass-windows64.exe *-host.json chrome-browserpass.crx *.ps1 README.md LICENSE

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,0 +1,31 @@
+$app = 'com.dannyvankooten.browserpass'
+$dirpath = Join-Path -Path $env:localappdata -ChildPath 'browserpass'
+
+if (Test-Path -Path $dirPath) {
+    Remove-Item -Recurse -Force $dirpath
+}
+
+If (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(`
+            [Security.Principal.WindowsBuiltInRole] "Administrator")) {
+    Write-Warning "Please re-run this script with Admin rights!"
+    exit
+}
+
+If (Test-Path -Path "hklm:\Software\Google\Chrome\NativeMessagingHosts\$app") {
+    Write-Host "Uninstalling for Chrome - all users"
+    Remove-Item -Path "hklm:\Software\Google\Chrome\NativeMessagingHosts\$app" -force
+}
+if (Test-Path -Path "hklm:\Software\Mozilla\NativeMessagingHosts\$app") {
+    Write-Host "Uninstalling for Firefox - all users"
+    Remove-Item -Path "hklm:\Software\Mozilla\NativeMessagingHosts\$app" -force
+}
+
+if (Test-Path -Path "hkcu:\Software\Mozilla\NativeMessagingHosts\$app") {
+    Write-Host "Uninstalling for Firefox - local user"
+    Remove-Item -Path "hkcu:\Software\Mozilla\NativeMessagingHosts\$app" -force
+}
+
+if (Test-Path -Path "hkcu:\Software\Google\Chrome\NativeMessagingHosts\$app") {
+    Write-Host "Uninstalling for Chrome - local user"
+    Remove-Item -Path "hkcu:\Software\Google\Chrome\NativeMessagingHosts\$app" -force
+}


### PR DESCRIPTION
Tested from the `browserpass-windows64.zip` file produced via `make release` in firefox and chrome with success (built from linux)!

Both extensions were installed from the respective "stores".

This fixes #133 