### PR TITLE
Add background script to Firefox manifest

### DIFF
--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -8,6 +8,12 @@
   "options_ui": {
     "page": "options.html"
   },
+  "background": {
+    "persistent": false,
+    "scripts": [
+      "background.js"
+    ]
+  },
   "browser_action": {
     "browser_style": false,
     "default_icon": "icon-lock.png",


### PR DESCRIPTION
The background script introduced in #119 was not added to the Firefox manifest, so the latest releases were not working on Firefox.