### PR TITLE
Select the fields without consideration of the case

### DIFF
--- a/chrome/inject.browserify.js
+++ b/chrome/inject.browserify.js
@@ -1,7 +1,7 @@
 (function(d) {
   const USERNAME_FIELDS =
-    "input[id=username], input[id=user_name], input[id=userid], input[id=user_id], input[id=login], input[id=email], input[type=email], input[type=text]";
-  const PASSWORD_FIELDS = "input[type=password]";
+    "input[id=username i], input[id=user_name i], input[id=userid i], input[id=user_id i], input[id=login i], input[id=email i], input[type=email i], input[type=text i]";
+  const PASSWORD_FIELDS = "input[type=password i]";
 
   function queryAllVisible(parent, selector, form) {
     var result = [];


### PR DESCRIPTION
The case of the fields name shouldn't be considered while selecting the the fields for the username/password.

[Here](https://drafts.csswg.org/selectors-4/#attribute-case) is the spec for the _i_ identifier.