### PR TITLE
Add Dockerfile for builds within docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ chrome/inject.js
 node_modules
 .vagrant/
 vendor/
+.*.swp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # CONTRIBUTING
 
-You will need Node, [Yarn](https://yarnpkg.com/), Golang and [dep](https://github.com/golang/dep) installed.
+You will need docker or Node, [Yarn](https://yarnpkg.com/), Golang and [dep](https://github.com/golang/dep) installed.
 
 ## To build
 - Open `makefile` and, if needed, change `google-chrome` to the appropriate name of your Google Chrome executable (in Linux, it could be google-chrome-stable)
@@ -8,6 +8,22 @@ You will need Node, [Yarn](https://yarnpkg.com/), Golang and [dep](https://githu
 - Run `make release`
 
 The command above will generate packed extensions for both Firefox and Chrome and compile the Go binaries for Linux and MacOSX.
+
+## Build using Docker
+
+The [Dockerfile](Dockerfile) will set up a docker image suitable for running basic make targets such as building frontend and backend.
+
+The `chrome` target is not supported by now (therefore `release` target will not work).
+
+To build the docker image run the following command in project root:
+```shell
+docker build -t browserpass-dev .
+```
+
+To build browserpass (frontend and backend) via docker, run the following from project root:
+```shell
+docker run --rm -v "$(pwd)":/browserpass browserpass-dev browserpass js
+```
 
 ## Setting up a Vagrant build environment and building the Linux binary
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.8-alpine3.6
+
+ENV CGO_ENABLED=0 \
+    APP_PATH="$GOPATH/src/github.com/dannyvankooten/browserpass"
+# New ENV statement as this depends on APP_PATH
+ENV PATH="$PATH:$APP_PATH/node_modules/.bin/"
+
+RUN apk add --no-cache bash git make tar yarn zip && \
+    go get -u github.com/golang/dep/cmd/dep && \
+    mkdir -p $APP_PATH && \
+    ln -s $APP_PATH /
+
+WORKDIR $APP_PATH
+
+ENTRYPOINT ["make"]


### PR DESCRIPTION
Just in case anyone is interested. This can be used to build browserpass (go and js) with docker-powers:
```
# Run once
docker build -t browserpass-dev .

# Repeat while hacking & for updates
docker run --rm -v "$(pwd)":/app browserpass-dev browserpass js
```