### PR TITLE
Simplify usage of make

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,8 @@
 You will need Node, [Yarn](https://yarnpkg.com/), Golang and [dep](https://github.com/golang/dep) installed.
 
 ## To build
-- Open `makefile` and, if needed, change `google-chrome` to the appropriate name of your Google Chrome executable (in Linux, it could be google-chrome-stable)
-- Run `make deps` to install Node/GO dependencies
-- Run `make release`
+- Run `make js` to compile front-end code
+- Run `make browserpass` to compile back-end code
 
 The command above will generate packed extensions for both Firefox and Chrome and compile the Go binaries for Linux and MacOSX.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,26 @@
 You will need Node, [Yarn](https://yarnpkg.com/), Golang and [dep](https://github.com/golang/dep) installed.
 
 ## To build
-- Run `make js` to compile front-end code
-- Run `make browserpass` to compile back-end code
+- Run `make` to compile both front-end and back-end code
 
-The command above will generate packed extensions for both Firefox and Chrome and compile the Go binaries for Linux and MacOSX.
+OR
+
+- Run `make js` to compile only front-end code
+- Run `make browserpass` to compile only back-end code
+
+The commands above will generate unpacked extensions for both Firefox and Chrome and compile the Go binaries for all supported platforms.
+
+## To load an unpacked extension
+- Run `./install.sh` or `./install.ps1` to install the compiled Go binary
+- For Chrome:
+    - Go to `chrome://extensions`
+    - Enable `Developer mode`
+    - Click `Load unpacked extension`
+    - Select `browserpass/chrome` directory
+- For Firefox:
+    - Go to `about:debugging#addons`
+    - Click `Load temporary add-on`
+    - Select `browserpass/firefox` directory
 
 ## Setting up a Vagrant build environment and building the Linux binary
 

--- a/makefile
+++ b/makefile
@@ -3,11 +3,10 @@ CHROME := $(shell which google-chrome 2>/dev/null || which google-chrome-stable 
 PEM := $(shell find . -name "chrome-browserpass.pem")
 JS_OUTPUT := chrome/script.js chrome/inject.js
 
-.PHONY: empty
-empty:
+all: js browserpass
 
-.PHONY: chrome
-chrome:
+.PHONY: crx
+crx:
 ifeq ($(PEM),./chrome-browserpass.pem)
 	"$(CHROME)" --disable-gpu --pack-extension=./chrome --pack-extension-key=$(PEM)
 else
@@ -16,14 +15,11 @@ else
 endif
 	mv chrome.crx chrome-browserpass.crx
 
-.PHONY: firefox
-firefox:
-	cp chrome/{*.html,*.css,*.js,*.png,*.svg} firefox/
-
 .PHONY: js
 js: deps $(JS_OUTPUT)
 	cp chrome/host.json chrome-host.json
 	cp firefox/host.json firefox-host.json
+	cp chrome/{*.html,*.css,*.js,*.png,*.svg} firefox/
 
 chrome/script.js: chrome/script.browserify.js
 	browserify chrome/script.browserify.js -o chrome/script.js
@@ -50,6 +46,7 @@ browserpass-freebsd64: deps cmd/browserpass/ pass/ browserpass.go
 	env GOOS=freebsd GOARCH=amd64 go build -o $@ ./cmd/browserpass
 
 clean:
+	rm -f browserpass
 	rm -f browserpass-*
 	rm -rf release
 	git clean -fdx chrome/
@@ -75,8 +72,8 @@ tarball: clean js
 	mkdir -p release
 	cp /tmp/browserpass-src.tar.gz release/
 
-.PHONY: release js chrome firefox
-release: clean js tarball chrome firefox browserpass-linux64 browserpass-darwinx64 browserpass-openbsd64 browserpass-freebsd64 browserpass-windows64
+.PHONY: release js crx
+release: clean js tarball crx browserpass-linux64 browserpass-darwinx64 browserpass-openbsd64 browserpass-freebsd64 browserpass-windows64
 	mkdir -p release
 	cp chrome-browserpass.crx release/
 	zip -jFS "release/chrome" chrome/* chrome-browserpass.crx

--- a/makefile
+++ b/makefile
@@ -21,7 +21,9 @@ firefox:
 	cp chrome/{*.html,*.css,*.js,*.png,*.svg} firefox/
 
 .PHONY: js
-js: $(JS_OUTPUT)
+js: deps $(JS_OUTPUT)
+	cp chrome/host.json chrome-host.json
+	cp firefox/host.json firefox-host.json
 
 chrome/script.js: chrome/script.browserify.js
 	browserify chrome/script.browserify.js -o chrome/script.js
@@ -29,27 +31,22 @@ chrome/script.js: chrome/script.browserify.js
 chrome/inject.js: chrome/inject.browserify.js
 	browserify chrome/inject.browserify.js -o chrome/inject.js
 
-.PHONY: static-files
-static-files: chrome/host.json firefox/host.json
-	cp chrome/host.json chrome-host.json
-	cp firefox/host.json firefox-host.json
-
-browserpass: cmd/browserpass/ pass/ browserpass.go
+browserpass: deps cmd/browserpass/ pass/ browserpass.go
 	go build -o $@ ./cmd/browserpass
 
-browserpass-linux64: cmd/browserpass/ pass/ browserpass.go
+browserpass-linux64: deps cmd/browserpass/ pass/ browserpass.go
 	env GOOS=linux GOARCH=amd64 go build -o $@ ./cmd/browserpass
 
-browserpass-windows64: cmd/browserpass/ pass/ browserpass.go
+browserpass-windows64: deps cmd/browserpass/ pass/ browserpass.go
 	env GOOS=windows GOARCH=amd64 go build -o $@.exe ./cmd/browserpass
 
-browserpass-darwinx64: cmd/browserpass/ pass/ browserpass.go
+browserpass-darwinx64: deps cmd/browserpass/ pass/ browserpass.go
 	env GOOS=darwin GOARCH=amd64 go build -o $@ ./cmd/browserpass
 
-browserpass-openbsd64: cmd/browserpass/ pass/ browserpass.go
+browserpass-openbsd64: deps cmd/browserpass/ pass/ browserpass.go
 	env GOOS=openbsd GOARCH=amd64 go build -o $@ ./cmd/browserpass
 
-browserpass-freebsd64: cmd/browserpass/ pass/ browserpass.go
+browserpass-freebsd64: deps cmd/browserpass/ pass/ browserpass.go
 	env GOOS=freebsd GOARCH=amd64 go build -o $@ ./cmd/browserpass
 
 clean:
@@ -69,7 +66,7 @@ deps:
 	yarn
 	dep ensure
 
-tarball: clean deps js static-files
+tarball: clean js
 	rm -rf /tmp/browserpass /tmp/browserpass-src.tar.gz
 	cp -r ../browserpass /tmp/browserpass
 	rm -rf /tmp/browserpass/.git
@@ -78,8 +75,8 @@ tarball: clean deps js static-files
 	mkdir -p release
 	cp /tmp/browserpass-src.tar.gz release/
 
-.PHONY: static-files js chrome firefox
-release: clean deps js static-files tarball chrome firefox browserpass-linux64 browserpass-darwinx64 browserpass-openbsd64 browserpass-freebsd64 browserpass-windows64
+.PHONY: release js chrome firefox
+release: clean js tarball chrome firefox browserpass-linux64 browserpass-darwinx64 browserpass-openbsd64 browserpass-freebsd64 browserpass-windows64
 	mkdir -p release
 	cp chrome-browserpass.crx release/
 	zip -jFS "release/chrome" chrome/* chrome-browserpass.crx


### PR DESCRIPTION
* All variants of Chrome binaries are already defined in makefile, no need to change it.
* Developers should be concerned only of two make goals, `make js` and `make browserpass`
    * /cc @jayme-github - this is what mostly needed from Docker to support
    * `make release` doesn't make sense to be used for regular people, as without my `*.pem` file extension will get a different ID and host app will not work with it.
* Dependencies will always be fetched automatically.
* Package maintainers should not be using `make` anymore as browserpass-src.tar.gz (made with `make tarball`) contains everything.


@qbit, @chrboe - let me know if this change makes sense to you, as I'm still not very comfortable with makefiles.