### PR TITLE
Find gpg even if it is not in $PATH, cleanup gpg options

### DIFF
--- a/browserpass.go
+++ b/browserpass.go
@@ -93,7 +93,7 @@ func Run(stdin io.Reader, stdout io.Writer, s pass.Store) error {
 	}
 }
 
-func detectGPGBin() (string, []string, error) {
+func detectGPGBin() (string, error) {
 	binPriorityList := []string{
 		"gpg2", "/bin/gpg2", "/usr/bin/gpg2", "/usr/local/bin/gpg2",
 		"gpg", "/bin/gpg", "/usr/bin/gpg", "/usr/local/bin/gpg",
@@ -109,26 +109,20 @@ func detectGPGBin() (string, []string, error) {
 	}
 
 	if binToUse == "" {
-		return "", nil, errors.New("Unable to detect the location of gpg binary")
+		return "", errors.New("Unable to detect the location of gpg binary")
 	}
 
-	opts := []string{"--decrypt", "--yes", "--quiet"}
-	if binToUse[len(binToUse)-1] == '2' {
-		opts = append(opts, "--use-agent", "--batch")
-	}
-
-	// Tell gpg to read from stdin
-	opts = append(opts, "-")
-
-	return binToUse, opts, nil
+	return binToUse, nil
 }
 
 // readLoginGPG reads a encrypted login from r using the system's GPG binary.
 func readLoginGPG(r io.Reader) (*Login, error) {
-	gpgbin, opts, err := detectGPGBin()
+	gpgbin, err := detectGPGBin()
 	if err != nil {
 		return nil, err
 	}
+
+	opts := []string{"--decrypt", "--yes", "--quiet", "--batch", "-"}
 
 	// Run gpg
 	cmd := exec.Command(gpgbin, opts...)


### PR DESCRIPTION
- Detect location of gpg binary even if $PATH is not set
- Cleanup gpg options
    - --use-agent is obsolete and has no effect since v2 according to man 
    - --batch existed even in v1, why not enable it always (and who the hell is using v1 today anyways?)

#13

--------

[browserpass-windows64.zip](https://github.com/dannyvankooten/browserpass/files/1338957/browserpass-windows64.zip)
[browserpass-freebsd64.zip](https://github.com/dannyvankooten/browserpass/files/1338958/browserpass-freebsd64.zip)
[browserpass-openbsd64.zip](https://github.com/dannyvankooten/browserpass/files/1338960/browserpass-openbsd64.zip)
[browserpass-darwinx64.zip](https://github.com/dannyvankooten/browserpass/files/1338959/browserpass-darwinx64.zip)
[browserpass-linux64.zip](https://github.com/dannyvankooten/browserpass/files/1338961/browserpass-linux64.zip)
