### PR TITLE
Keep popup open while searching, show error from host app

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -30,7 +30,9 @@ function onMessage(request, sender, sendResponse) {
       { action: "get", entry: request.entry },
       function(response) {
         if (chrome.runtime.lastError) {
-          console.log(chrome.runtime.lastError);
+          var error = chrome.runtime.lastError.message;
+          console.error(error);
+          sendResponse({ status: "ERROR", error: error });
         }
 
         chrome.tabs.query({ currentWindow: true, active: true }, function(
@@ -41,8 +43,12 @@ function onMessage(request, sender, sendResponse) {
             fillLoginForm(response, request.urlDuringSearch);
           }
         });
-        sendResponse();
+
+        sendResponse({ status: "OK" });
       }
     );
+
+    // Need to return true if we are planning to sendResponse asynchronously
+    return true;
   }
 }


### PR DESCRIPTION
This fixes #170, but also introduces a frontend framework for displaying meaningful errors needed for #164.

Demo 1, successful password retrieval with artificially introduced delay to show that we have loading icon back:

![browserpass_success](https://user-images.githubusercontent.com/1177900/31137213-dfe399ce-a86a-11e7-8e0d-6f5a1ed3ca65.gif)

Demo 2, showing an error after communicating to the host app:

![browserpass_error](https://user-images.githubusercontent.com/1177900/31137138-9a8b0a42-a86a-11e7-9c6e-b530b972980c.gif)


FYI @chrboe, @benjumanji