### PR TITLE
Add instructions for installing on Windows through WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,19 @@ Installing the binary & registering it with your browser through the installatio
 
 #### Installing the host application on Windows through WSL
 
+If you already use `pass` under WSL and prefer to have a single copy of your password store, you can use browserpass through WSL as well.
 1. Install the Windows host application (see previous section) as well as the Linux host application (under WSL).
-2. Create `%localappdata%\browserpass\browserpass-linux.bat` with the following contents:
+2. Create `%localappdata%\browserpass\browserpass-wsl.bat` with the following contents:
 ```
 @echo off
-bash -c ~/browserpass/browserpass-linux64
+bash -c ~/.browserpass/browserpass-linux64
 ```
-3. Change the path in `%localappdata%\browserpass\browserpass-firefox.json` (or `-chrome.json`) to point to `browserpass-linux.bat`
+If you installed the Linux host application in a location different from `~/.browserpass`, replace that path in the above script.
+
+3. Change the path in `%localappdata%\browserpass\browserpass-firefox.json` (or `-chrome.json`) to point to `browserpass-wsl.bat`
+
+If your GPG key has a password, the host application running under WSL won't be able to unlock it since it can't interactively prompt for the password. This means you can't get decrypt any passwords unless you've already got the key loaded in gpg-agent.
+As a workaround, you can use the key (`pass website.com`) in a WSL terminal to load the key into gpg-agent. Then browserpass will work until gpg-agent times out.
 
 #### Installing the Chrome extension
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you installed the Linux host application in a location different from `~/.bro
 
 3. Change the path in `%localappdata%\browserpass\browserpass-firefox.json` (or `-chrome.json`) to point to `browserpass-wsl.bat`
 
-If your GPG key has a password, the host application running under WSL won't be able to unlock it since it can't interactively prompt for the password. This means you can't get decrypt any passwords unless you've already got the key loaded in gpg-agent.
+If your GPG key has a password, the host application running under WSL won't be able to unlock it since it can't interactively prompt for the password. This means you can't decrypt any passwords unless you've already got the key loaded in gpg-agent.
 As a workaround, you can use the key (`pass website.com`) in a WSL terminal to load the key into gpg-agent. Then browserpass will work until gpg-agent times out.
 
 #### Installing the Chrome extension

--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ All release files are signed with [this PGP key](https://keybase.io/maximbaz). T
 
 Installing the binary & registering it with your browser through the installation script is required to allow the browser extension to talk to the local binary application.
 
+#### Installing the host application on Windows through WSL
+
+1. Install the Windows host application (see previous section) as well as the Linux host application (under WSL).
+2. Create `%localappdata%\browserpass\browserpass-linux.bat` with the following contents:
+```
+@echo off
+bash -c ~/browserpass/browserpass-linux64
+```
+3. Change the path in `%localappdata%\browserpass\browserpass-firefox.json` (or `-chrome.json`) to point to `browserpass-linux.bat`
+
 #### Installing the Chrome extension
 
 You can either [install the Chrome extension from the Chrome Web Store](https://chrome.google.com/webstore/detail/browserpass/naepdomgkenhinolocfifgehidddafch) or drag the `chrome-browserpass.crx` file from the release package into the [Chrome Extensions](chrome://extensions) (`chrome://extensions`) page.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you installed the Linux host application in a location different from `~/.bro
 3. Change the path in `%localappdata%\browserpass\browserpass-firefox.json` (or `-chrome.json`) to point to `browserpass-wsl.bat`
 
 If your GPG key has a password, the host application running under WSL won't be able to unlock it since it can't interactively prompt for the password. This means you can't decrypt any passwords unless you've already got the key loaded in gpg-agent.
-As a workaround, you can use the key (`pass website.com`) in a WSL terminal to load the key into gpg-agent. Then browserpass will work until gpg-agent times out.
+As a workaround, you can use the key (`pass website.com`) in a WSL terminal to load the key into gpg-agent. Then browserpass will work until gpg-agent times out (it is possible to configure larger timeouts, check manual for gpg-agent).
 
 #### Installing the Chrome extension
 


### PR DESCRIPTION
Moving instructions for working with WSL to README.md.
Some stuff to look at:
- Automatically create `browserpass-linux.bat` with `install.ps1` to simplify the instructions? (it can just sit there unused normally)
- If your GPG key has a password (which it really should), the host running under WSL won't be able to unlock it since it can't prompt the user for the password. This means you can't get decrypt any passwords unless you've already got the key loaded in gpg-agent.
Could possibly handle this by prompting for the master password in the browser extension in this case? Seems kinda sketchy though, especially for such an edge case.