### PR TITLE
Change default value for autoSubmit option for new users

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -11,7 +11,7 @@ chrome.tabs.onUpdated.addListener(onTabUpdated);
 function fillLoginForm(login, tab) {
   const loginParam = JSON.stringify(login);
   const autoSubmit = localStorage.getItem("autoSubmit");
-  const autoSubmitParam = autoSubmit != "false";
+  const autoSubmitParam = autoSubmit == "true";
   if (autoSubmit === null) {
     localStorage.setItem("autoSubmit", autoSubmitParam);
   }

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -5,7 +5,7 @@ function save_options() {
 }
 
 function restore_options() {
-  var autoSubmit = localStorage.getItem("autoSubmit") != "false";
+  var autoSubmit = localStorage.getItem("autoSubmit") == "true";
   document.getElementById("auto-submit").checked = autoSubmit;
 }
 


### PR DESCRIPTION
Since this is a breaking change, I will merge this somewhere in the middle of January, this should give enough time to the current users to upgrade to v2.0.10 and save their currently used value of autoSubmit to localStorage.