### PR TITLE
Add builtin fuzzy support to browserpass #32

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,6 +17,18 @@
   revision = "cb5263554791976bf8cdd747c82355370893ecd7"
 
 [[projects]]
+  name = "github.com/renstrom/fuzzysearch"
+  packages = ["fuzzy"]
+  revision = "d4ca9dfccd55dc6b076f9880d49c35315922c1f4"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/sahilm/fuzzy"
+  packages = ["."]
+  revision = "0e1c4a4e1f632f936a5c0fa6176076eea01c054b"
+  version = "v0.0.3"
+
+[[projects]]
   branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
@@ -35,6 +47,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cf738c6ba5f7f4087970a763781d0a3184aae44ca125d025f7b1a91128b3bd0c"
+  inputs-digest = "2127faf99d082ab05f16eb3309a4cd8807a7228bcb2dd121d5ca951ac4ce1092"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,12 +17,6 @@
   revision = "cb5263554791976bf8cdd747c82355370893ecd7"
 
 [[projects]]
-  name = "github.com/renstrom/fuzzysearch"
-  packages = ["fuzzy"]
-  revision = "d4ca9dfccd55dc6b076f9880d49c35315922c1f4"
-  version = "v1.0.0"
-
-[[projects]]
   name = "github.com/sahilm/fuzzy"
   packages = ["."]
   revision = "0e1c4a4e1f632f936a5c0fa6176076eea01c054b"
@@ -47,6 +41,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2127faf99d082ab05f16eb3309a4cd8807a7228bcb2dd121d5ca951ac4ce1092"
+  inputs-digest = "d14ee1e21acbc5485af24c8de94d50a9e3f9154712df345f9320cff01f2d4a37"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/browserpass.go
+++ b/browserpass.go
@@ -33,8 +33,7 @@ var endianness = binary.LittleEndian
 // which options have been selected by the user, and put them in a JSON object
 // which is then passed along with the command over the native messaging api.
 type Config struct {
-	UseFuzzy       bool   `json:"use_fuzzy"`       // If false, use legacy glob search
-	FuzzyAlgorithm string `json:"fuzzy_algorithm"` // The name of the fuzzy algorithm to use
+	UseFuzzy bool `json:"use_fuzzy"` // If false, use legacy glob search
 }
 
 // msg defines a message sent from a browser extension.
@@ -66,7 +65,7 @@ func Run(stdin io.Reader, stdout io.Writer, s pass.Store) error {
 
 		// Since the pass.Store object is created by the wrapper prior to
 		// settings from the browser being made available, we set them here
-		s.SetConfig(nil, &data.Settings.UseFuzzy, &data.Settings.FuzzyAlgorithm)
+		s.SetConfig(nil, &data.Settings.UseFuzzy)
 
 		var resp interface{}
 		switch data.Action {

--- a/browserpass.go
+++ b/browserpass.go
@@ -12,9 +12,6 @@ import (
 	"regexp"
 	"strings"
 
-	"fmt"
-	"os"
-
 	"github.com/dannyvankooten/browserpass/pass"
 	"github.com/dannyvankooten/browserpass/protector"
 	"github.com/gokyle/twofactor"
@@ -36,7 +33,8 @@ var endianness = binary.LittleEndian
 // which options have been selected by the user, and put them in a JSON object
 // which is then passed along with the command over the native messaging api.
 type Config struct {
-	UseFuzzy bool `json:"use_fuzzy"` // If false, use legacy glob search
+	// Manual searches use FuzzySearch if true, GlobSearch otherwise
+	UseFuzzy bool `json:"use_fuzzy_search"`
 }
 
 // msg defines a message sent from a browser extension.
@@ -79,10 +77,7 @@ func Run(stdin io.Reader, stdout io.Writer, s pass.Store) error {
 			}
 			resp = list
 		case "match_domain":
-			fmt.Fprintf(os.Stderr, "Got match domain, data is: %s\n", data.Domain)
-			data.Settings.UseFuzzy = false
-			s.SetConfig(nil, &data.Settings.UseFuzzy)
-			list, err := s.Search(data.Domain)
+			list, err := s.GlobSearch(data.Domain)
 			if err != nil {
 				return err
 			}

--- a/browserpass.go
+++ b/browserpass.go
@@ -66,7 +66,7 @@ func Run(stdin io.Reader, stdout io.Writer, s pass.Store) error {
 
 		// Since the pass.Store object is created by the wrapper prior to
 		// settings from the browser being made available, we set them here
-		s.SetConfig(nil, &data.Settings.UseFuzzy)
+		s.SetConfig(&data.Settings.UseFuzzy)
 
 		var resp interface{}
 		switch data.Action {

--- a/browserpass.go
+++ b/browserpass.go
@@ -12,6 +12,9 @@ import (
 	"regexp"
 	"strings"
 
+	"fmt"
+	"os"
+
 	"github.com/dannyvankooten/browserpass/pass"
 	"github.com/dannyvankooten/browserpass/protector"
 	"github.com/gokyle/twofactor"
@@ -70,6 +73,15 @@ func Run(stdin io.Reader, stdout io.Writer, s pass.Store) error {
 		var resp interface{}
 		switch data.Action {
 		case "search":
+			list, err := s.Search(data.Domain)
+			if err != nil {
+				return err
+			}
+			resp = list
+		case "match_domain":
+			fmt.Fprintf(os.Stderr, "Got match domain, data is: %s\n", data.Domain)
+			data.Settings.UseFuzzy = false
+			s.SetConfig(nil, &data.Settings.UseFuzzy)
 			list, err := s.Search(data.Domain)
 			if err != nil {
 				return err

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -90,7 +90,7 @@ function onMessage(request, sender, sendResponse) {
   // object that has current settings. Update this as new settings
   // are added (or old ones removed)
   if (request.action == "getSettings") {
-    const use_fuzzy_search = localStorage.getItem("use_fuzzy_search") == "true";
+    const use_fuzzy_search = localStorage.getItem("use_fuzzy_search") != "false";
     sendResponse({ use_fuzzy_search: use_fuzzy_search})
   }
 }

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -85,6 +85,15 @@ function onMessage(request, sender, sendResponse) {
   if (request.action == "dismissOTP" && sender.tab.id in tabInfos) {
     delete tabInfos[sender.tab.id];
   }
+
+  // allows the local communication to request settings. Returns an
+  // object that has current settings. Update this as new settings
+  // are added (or old ones removed)
+  if (request.action == "getSettings") {
+    const use_fuzzy = localStorage.getItem("use_fuzzy") == "true";
+    const fuzzy_algorithm = localStorage.getItem("fuzzy_algorithm");
+    sendResponse({ use_fuzzy: use_fuzzy, fuzzy_algorithm: fuzzy_algorithm })
+  }
 }
 
 function onTabUpdated(tabId, changeInfo, tab) {

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -90,9 +90,8 @@ function onMessage(request, sender, sendResponse) {
   // object that has current settings. Update this as new settings
   // are added (or old ones removed)
   if (request.action == "getSettings") {
-    const use_fuzzy = localStorage.getItem("use_fuzzy") == "true";
-    const fuzzy_algorithm = localStorage.getItem("fuzzy_algorithm");
-    sendResponse({ use_fuzzy: use_fuzzy, fuzzy_algorithm: fuzzy_algorithm })
+    const use_fuzzy_search = localStorage.getItem("use_fuzzy_search") == "true";
+    sendResponse({ use_fuzzy_search: use_fuzzy_search})
   }
 }
 

--- a/chrome/options.html
+++ b/chrome/options.html
@@ -13,7 +13,6 @@
   Auto-Submit login forms
 </label>
 <br/>
-<!-- Options related to FuzzyFinder search -->
 <label>
   <input type="checkbox" id="use-fuzzy">
   Use fuzzy search

--- a/chrome/options.html
+++ b/chrome/options.html
@@ -13,6 +13,20 @@
   Auto-Submit login forms
 </label>
 <br/>
+<!-- Options related to FuzzyFinder search -->
+<label>
+  <input type="checkbox" id="use-fuzzy">
+  Use fuzzy search
+</label>
+<br/>
+<label> Fuzzy Search Algornitm </label>
+<label>
+  <input type="radio" name="fuzzyalgo" value="sahilm" checked> Sahilm
+</label>
+<label>
+  <input type="radio" name="fuzzyalgo" value="renstrom"> Renstrom
+</label>
+<br/>
 <br/>
 <button id="save">Save</button>
 

--- a/chrome/options.html
+++ b/chrome/options.html
@@ -19,14 +19,6 @@
   Use fuzzy search
 </label>
 <br/>
-<label> Fuzzy Search Algornitm </label>
-<label>
-  <input type="radio" name="fuzzyalgo" value="sahilm" checked> Sahilm
-</label>
-<label>
-  <input type="radio" name="fuzzyalgo" value="renstrom"> Renstrom
-</label>
-<br/>
 <br/>
 <button id="save">Save</button>
 

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -3,10 +3,10 @@ function save_options() {
   localStorage.setItem("autoSubmit", autoSubmit);
 
   // Options related to fuzzy finding.
-  //  use_fuzzy indicates if any fuzzy finding should be used, or if
-  //  the glob search should be used when a user inputs a string to search
+  //  use_fuzzy_search indicates if fuzzy finding or glob searching should
+  //  be used in manual searches
   var use_fuzzy = document.getElementById("use-fuzzy").checked;
-  localStorage.setItem("use_fuzzy", use_fuzzy);
+  localStorage.setItem("use_fuzzy_search", use_fuzzy);
 
   window.close();
 }
@@ -16,7 +16,7 @@ function restore_options() {
   document.getElementById("auto-submit").checked = autoSubmit;
 
   // Restore the view to show the settings described above
-  var use_fuzzy = localStorage.getItem("use_fuzzy") == "true";
+  var use_fuzzy = localStorage.getItem("use_fuzzy_search") != "false";
   document.getElementById("use-fuzzy").checked = use_fuzzy;
 }
 

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -8,12 +8,6 @@ function save_options() {
   var use_fuzzy = document.getElementById("use-fuzzy").checked;
   localStorage.setItem("use_fuzzy", use_fuzzy);
 
-  // fuzzy_algorithm - since there are two libraries being evaluated
-  // provide a way to select between them withoug needing rebuild
-  // of the browserpass native client.
-  var fuzzy_algorithm = document.querySelector('input[name="fuzzyalgo"]:checked').value;
-  localStorage.setItem("fuzzy_algorithm", fuzzy_algorithm);
-
   window.close();
 }
 
@@ -24,17 +18,6 @@ function restore_options() {
   // Restore the view to show the settings described above
   var use_fuzzy = localStorage.getItem("use_fuzzy") == "true";
   document.getElementById("use-fuzzy").checked = use_fuzzy;
-
-  var fuzzy_algorithm = localStorage.getItem("fuzzy_algorithm");
-  if (fuzzy_algorithm != null) {
-    document.getElementsByName("fuzzyalgo").forEach(function(elem) {
-      if (elem.value == fuzzy_algorithm) {
-        elem.checked = true;
-      } else {
-        elem.checked = false;
-      }
-    });
-  }
 }
 
 document.addEventListener("DOMContentLoaded", restore_options);

--- a/chrome/options.js
+++ b/chrome/options.js
@@ -1,12 +1,40 @@
 function save_options() {
   var autoSubmit = document.getElementById("auto-submit").checked;
   localStorage.setItem("autoSubmit", autoSubmit);
+
+  // Options related to fuzzy finding.
+  //  use_fuzzy indicates if any fuzzy finding should be used, or if
+  //  the glob search should be used when a user inputs a string to search
+  var use_fuzzy = document.getElementById("use-fuzzy").checked;
+  localStorage.setItem("use_fuzzy", use_fuzzy);
+
+  // fuzzy_algorithm - since there are two libraries being evaluated
+  // provide a way to select between them withoug needing rebuild
+  // of the browserpass native client.
+  var fuzzy_algorithm = document.querySelector('input[name="fuzzyalgo"]:checked').value;
+  localStorage.setItem("fuzzy_algorithm", fuzzy_algorithm);
+
   window.close();
 }
 
 function restore_options() {
   var autoSubmit = localStorage.getItem("autoSubmit") == "true";
   document.getElementById("auto-submit").checked = autoSubmit;
+
+  // Restore the view to show the settings described above
+  var use_fuzzy = localStorage.getItem("use_fuzzy") == "true";
+  document.getElementById("use-fuzzy").checked = use_fuzzy;
+
+  var fuzzy_algorithm = localStorage.getItem("fuzzy_algorithm");
+  if (fuzzy_algorithm != null) {
+    document.getElementsByName("fuzzyalgo").forEach(function(elem) {
+      if (elem.value == fuzzy_algorithm) {
+        elem.checked = true;
+      } else {
+        elem.checked = false;
+      }
+    });
+  }
 }
 
 document.addEventListener("DOMContentLoaded", restore_options);

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -115,20 +115,28 @@ function searchPassword(_domain) {
   urlDuringSearch = activeTab.url;
   m.redraw();
 
-  chrome.runtime.sendNativeMessage(
-    app,
-    { action: "search", domain: _domain },
+  // First get the settings needed by the browserpass native client
+  // by requesting them from the background script (which has localStorage access
+  // to the settings). Then construct the message to send to browserpass and
+  // send that via sendNativeMessage.
+  chrome.runtime.sendMessage(
+    { action: "getSettings" },
     function(response) {
-      if (chrome.runtime.lastError) {
-        error = chrome.runtime.lastError.message;
-        console.error(error);
-      }
+      chrome.runtime.sendNativeMessage(
+        app,
+        { action: "search", domain: _domain, settings: response},
+        function(response) {
+          if (chrome.runtime.lastError) {
+            error = chrome.runtime.lastError.message;
+            console.error(error);
+          }
 
-      searching = false;
-      logins = response;
-      m.redraw();
-    }
-  );
+          searching = false;
+          logins = response;
+          m.redraw();
+        }
+      );
+    });
 }
 
 function parseDomainFromUrl(url) {

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -105,10 +105,10 @@ function init(tab) {
 
   activeTab = tab;
   var activeDomain = parseDomainFromUrl(tab.url);
-  searchPassword(activeDomain);
+  searchPassword(activeDomain, "match_domain");
 }
 
-function searchPassword(_domain) {
+function searchPassword(_domain, action="search") {
   searching = true;
   logins = null;
   domain = _domain;
@@ -124,7 +124,7 @@ function searchPassword(_domain) {
     function(response) {
       chrome.runtime.sendNativeMessage(
         app,
-        { action: "search", domain: _domain, settings: response},
+        { action: action, domain: _domain, settings: response},
         function(response) {
           if (chrome.runtime.lastError) {
             error = chrome.runtime.lastError.message;

--- a/pass/disk.go
+++ b/pass/disk.go
@@ -11,10 +11,15 @@ import (
 	"os/user"
 
 	"github.com/mattn/go-zglob"
+	// Fuzzy matching packages
+	rfuzzy "github.com/renstrom/fuzzysearch/fuzzy"
+	sfuzzy "github.com/sahilm/fuzzy"
 )
 
 type diskStore struct {
-	path string
+	path           string
+	useFuzzy       bool   // Setting to use the fuzzy matcher or the legacy glob matching
+	fuzzyAlgorithm string // Setting to choose the fuzzy algorithm
 }
 
 func NewDefaultStore() (Store, error) {
@@ -23,7 +28,7 @@ func NewDefaultStore() (Store, error) {
 		return nil, err
 	}
 
-	return &diskStore{path}, nil
+	return &diskStore{path, false, ""}, nil
 }
 
 func defaultStorePath() (string, error) {
@@ -42,7 +47,97 @@ func defaultStorePath() (string, error) {
 	return filepath.EvalSymlinks(path)
 }
 
+// Set the configuration options for password matching.
+func (s *diskStore) SetConfig(path *string, use_fuzzy *bool, fuzzy_algorithm *string) error {
+	// do this first to detect error condition before changing other options
+	if fuzzy_algorithm != nil {
+		switch *fuzzy_algorithm {
+		case "sahilm", "renstrom":
+			s.fuzzyAlgorithm = *fuzzy_algorithm
+		default:
+			return errors.New("Bad fuzzy algorithm: " + *fuzzy_algorithm)
+		}
+	}
+
+	if path != nil {
+		//todo validate path exists
+		s.path = *path
+	}
+	if use_fuzzy != nil {
+		s.useFuzzy = *use_fuzzy
+	}
+	return nil
+}
+
+// Do a search. Will call into the correct algoritm (glob, fuzzy (renstrom) or fuzzy (sahilm)
+// based on the settings present in the diskStore struct
 func (s *diskStore) Search(query string) ([]string, error) {
+	// default legacy glob search
+	if !s.useFuzzy {
+		return s.GlobSearch(query)
+	}
+	// Algorithm chooser
+	switch s.fuzzyAlgorithm {
+	case "renstrom":
+		return s.renstromFuzzySearch(query)
+	case "sahilm":
+		return s.sahilmFuzzySerach(query)
+	}
+	return nil, errors.New("Bad settings combo - can't happen?")
+}
+
+// Fuzzy searches first get a list of all pass entries by doing a glob search
+// for the empty string, then apply appropriate logic relevant to the
+// specific algorithm, finally returning all of the unique entries.
+
+// Search based on the renstrom fuzzy package.
+func (s *diskStore) renstromFuzzySearch(query string) ([]string, error) {
+	var items []string
+	file_list, err := s.GlobSearch("")
+	if err != nil {
+		return nil, err
+	}
+
+	// use RankFind because raw matches have no sorting criteria.
+	// The RankFind is based on levenstein distance only, and returns
+	// and unsorted list, so we first sort the matches then create
+	// a slice of strings to return.
+	matches := rfuzzy.RankFind(query, file_list)
+	sort.Sort(matches)
+	// convert maches into a slice of strings - match.Target is the
+	// original string passed into the algorithm
+	for _, match := range matches {
+		items = append(items, match.Target)
+	}
+
+	result := unique(items)
+
+	return result, nil
+}
+
+// Use the sahilm Fuzzy search. This algoritm returns result sorted
+// by best match defined in the algroithm.
+func (s *diskStore) sahilmFuzzySerach(query string) ([]string, error) {
+	var items []string
+	file_list, err := s.GlobSearch("")
+	if err != nil {
+		return nil, err
+	}
+
+	// The resulting match struct does not copy the strings, but rather
+	// provides the index to the original array. Copy those strings
+	// into the result slice
+	matches := sfuzzy.Find(query, file_list)
+	for _, match := range matches {
+		items = append(items, file_list[match.Index])
+	}
+
+	result := unique(items)
+
+	return result, nil
+}
+
+func (s *diskStore) GlobSearch(query string) ([]string, error) {
 	// Search:
 	// 	1. DOMAIN/USERNAME.gpg
 	//	2. DOMAIN.gpg
@@ -69,7 +164,7 @@ func (s *diskStore) Search(query string) ([]string, error) {
 	if strings.Count(query, ".") >= 2 {
 		// try finding additional items by removing subparts of the query
 		queryParts := strings.SplitN(query, ".", 2)[1:]
-		newItems, err := s.Search(strings.Join(queryParts, "."))
+		newItems, err := s.GlobSearch(strings.Join(queryParts, "."))
 		if err != nil {
 			return nil, err
 		}

--- a/pass/disk.go
+++ b/pass/disk.go
@@ -59,14 +59,14 @@ func (s *diskStore) Search(query string) ([]string, error) {
 	if !s.useFuzzy {
 		return s.GlobSearch(query)
 	} else {
-		return s.FuzzySerach(query)
+		return s.FuzzySearch(query)
 	}
 }
 
 // Fuzzy searches first get a list of all pass entries by doing a glob search
 // for the empty string, then apply appropriate logic to convert results to
 // a slice of strings, finally returning all of the unique entries.
-func (s *diskStore) FuzzySerach(query string) ([]string, error) {
+func (s *diskStore) FuzzySearch(query string) ([]string, error) {
 	var items []string
 	file_list, err := s.GlobSearch("")
 	if err != nil {

--- a/pass/disk.go
+++ b/pass/disk.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 
+	"fmt"
+
 	"os/user"
 
 	"github.com/mattn/go-zglob"
@@ -62,8 +64,10 @@ func (s *diskStore) SetConfig(path *string, use_fuzzy *bool) error {
 func (s *diskStore) Search(query string) ([]string, error) {
 	// default legacy glob search
 	if !s.useFuzzy {
+		fmt.Fprintf(os.Stderr, "Doing globsearch\n")
 		return s.GlobSearch(query)
 	} else {
+		fmt.Fprintf(os.Stderr, "Doing fuzzy\n")
 		return s.sahilmFuzzySerach(query)
 	}
 }

--- a/pass/disk.go
+++ b/pass/disk.go
@@ -45,11 +45,7 @@ func defaultStorePath() (string, error) {
 }
 
 // Set the configuration options for password matching.
-func (s *diskStore) SetConfig(path *string, use_fuzzy *bool) error {
-	if path != nil {
-		//todo validate path exists
-		s.path = *path
-	}
+func (s *diskStore) SetConfig(use_fuzzy *bool) error {
 	if use_fuzzy != nil {
 		s.useFuzzy = *use_fuzzy
 	}

--- a/pass/pass.go
+++ b/pass/pass.go
@@ -13,4 +13,6 @@ var ErrNotFound = errors.New("pass: not found")
 type Store interface {
 	Search(query string) ([]string, error)
 	Open(item string) (io.ReadCloser, error)
+	// Update password store settings on the fly
+	SetConfig(path *string, use_fuzzy *bool, fuzzy_algorithm *string) error
 }

--- a/pass/pass.go
+++ b/pass/pass.go
@@ -14,5 +14,5 @@ type Store interface {
 	Search(query string) ([]string, error)
 	Open(item string) (io.ReadCloser, error)
 	// Update password store settings on the fly
-	SetConfig(path *string, use_fuzzy *bool, fuzzy_algorithm *string) error
+	SetConfig(path *string, use_fuzzy *bool) error
 }

--- a/pass/pass.go
+++ b/pass/pass.go
@@ -13,6 +13,7 @@ var ErrNotFound = errors.New("pass: not found")
 type Store interface {
 	Search(query string) ([]string, error)
 	Open(item string) (io.ReadCloser, error)
+	GlobSearch(query string) ([]string, error)
 	// Update password store settings on the fly
 	SetConfig(path *string, use_fuzzy *bool) error
 }

--- a/pass/pass.go
+++ b/pass/pass.go
@@ -15,5 +15,5 @@ type Store interface {
 	Open(item string) (io.ReadCloser, error)
 	GlobSearch(query string) ([]string, error)
 	// Update password store settings on the fly
-	SetConfig(path *string, use_fuzzy *bool) error
+	SetConfig(use_fuzzy *bool) error
 }


### PR DESCRIPTION
This adds builtin support for fuzzy finding in the browserpass search
bar. (Issue #32) It also adds options to:

1. Turn on/off the use of fuzzy search from the search bar.
2. Select which fuzzy finding algorithm to use.

The second option allows users to choose between:
* github.com/renstrom/fuzzysearch/fuzzy
* github.com/sahilm/fuzzy

NOTE: the selection of fuzzy algorithm should probably go away before
merging the branch, but it is included right now, since there was a
discussion on #209 about which of those algorithms would be right for
browserpass. This makes switching between the two for evaluation
simpler, until a decision can be made on which to include (or a decision
to keep as-is).