### PR TITLE
Implement as-you-type filtering

### DIFF
--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -97,11 +97,6 @@ function view() {
 }
 
 function filterLogins(e) {
-  // remove executed search from input field
-  if (!fillOnSubmit && e.target.value.indexOf(domain) === 0) {
-    e.target.value = e.target.value.substr(domain.length);
-  }
-
   // use fuzzy search to filter results
   var filter = e.target.value.trim().split(/[\s\/]+/);
   if (filter.length > 0) {
@@ -132,10 +127,10 @@ function filterLogins(e) {
 
 function searchKeyHandler(e) {
   // switch to search mode if '\' is pressed and no filter text has been entered
-  if (e.code == "Backspace" && logins && logins.length > 0 && (!e.target.value.length || e.target.value == domain)) {
+  if (e.code == "Backspace" && logins && logins.length > 0 && e.target.value.length == 0) {
     e.preventDefault();
     logins = resultLogins = [];
-    e.target.value = '';
+    e.target.value = fillOnSubmit ? '' : domain;
     showFilterHint(false);
   }
 }
@@ -207,7 +202,10 @@ function searchPassword(_domain, action="search", useFillOnSubmit=true) {
           logins = resultLogins = response ? response : [];
           document.getElementById("filter-search").textContent = domain;
           fillOnSubmit = useFillOnSubmit && logins && logins.length > 0;
-          showFilterHint(fillOnSubmit);
+          if (logins && logins.length > 0) {
+            showFilterHint(true);
+            document.getElementById("search-field").value = '';
+          }
           m.redraw();
         }
       );

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -76,7 +76,7 @@ function view() {
               type: "text",
               id: "search-field",
               name: "s",
-              placeholder: "Search password..",
+              placeholder: "Search passwords..",
               autocomplete: "off",
               autofocus: "on",
               oninput: filterLogins
@@ -147,10 +147,13 @@ function searchKeyHandler(e) {
 
 function showFilterHint(show=true) {
   var filterHint = document.getElementById("filter-search");
+  var searchField = document.getElementById("search-field");
   if (show) {
     filterHint.style.display = "block";
+    searchField.setAttribute("placeholder", "Refine search...");
   } else {
     filterHint.style.display = "none";
+    searchField.setAttribute("placeholder", "Search passwords...");
   }
 }
 

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -126,8 +126,8 @@ function filterLogins(e) {
 }
 
 function searchKeyHandler(e) {
-  // switch to search mode if '\' is pressed and no filter text has been entered
-  if (e.code == "Backspace" && logins && logins.length > 0 && e.target.value.length == 0) {
+  // switch to search mode if backspace is pressed and no filter text has been entered
+  if (e.code == "Backspace" && logins.length > 0 && e.target.value.length == 0) {
     e.preventDefault();
     logins = resultLogins = [];
     e.target.value = fillOnSubmit ? '' : domain;
@@ -150,7 +150,7 @@ function showFilterHint(show=true) {
 function submitSearchForm(e) {
   e.preventDefault();
 
-  if (fillOnSubmit && logins && logins.length > 0) {
+  if (fillOnSubmit && logins.length > 0) {
     // fill using the first result
     getLoginData.bind(logins[0])();
   } else {
@@ -201,7 +201,7 @@ function searchPassword(_domain, action="search", useFillOnSubmit=true) {
           searching = false;
           logins = resultLogins = response ? response : [];
           document.getElementById("filter-search").textContent = domain;
-          fillOnSubmit = useFillOnSubmit && logins && logins.length > 0;
+          fillOnSubmit = useFillOnSubmit && logins.length > 0;
           if (logins && logins.length > 0) {
             showFilterHint(true);
             document.getElementById("search-field").value = '';

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -103,11 +103,17 @@ function filterLogins(e) {
   }
 
   // use fuzzy search to filter results
-  var filter = e.target.value.trim();
+  var filter = e.target.value.trim().split(/[\s\/]+/);
   if (filter.length > 0) {
-    logins = [];
-    FuzzySort.go(filter, resultLogins, {allowTypo: false}).forEach(function(result) {
-      logins.push(result.target);
+    logins = resultLogins.slice(0);
+    filter.forEach(function(word) {
+      if (word.length > 0) {
+        var refine = [];
+        FuzzySort.go(word, logins, {allowTypo: false}).forEach(function(result) {
+          refine.push(result.target);
+        });
+        logins = refine.slice(0);
+      }
     });
 
     // fill login forms on submit rather than initiating a search

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -295,14 +295,16 @@ function keyHandler(e) {
       switchFocus("div.entry:first-child > .login", "nextElementSibling");
       break;
     case "c":
-      if (e.ctrlKey) {
+      if (e.target.id != "search-field" && e.ctrlKey) {
         document.activeElement["nextElementSibling"][
           "nextElementSibling"
         ].click();
       }
       break;
     case "C":
-      document.activeElement["nextElementSibling"].click();
+      if (e.target.id != "search-field") {
+        document.activeElement["nextElementSibling"].click();
+      }
       break;
   }
 }

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -124,6 +124,8 @@ function filterLogins(e) {
 
     // fill login forms on submit rather than initiating a search
     fillOnSubmit = logins.length > 0;
+  } else {
+    logins = resultLogins.slice(0);
   }
 
   // redraw the list

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -132,7 +132,7 @@ function filterLogins(e) {
   m.redraw();
 
   // show / hide the filter hint
-  showFilterHint(e.target.value.length > 0 || (logins && logins.length));
+  showFilterHint(logins && logins.length);
 }
 
 function searchKeyHandler(e) {

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -122,7 +122,7 @@ function filterLogins(e) {
   m.redraw();
 
   // show / hide the filter hint
-  showFilterHint(logins && logins.length);
+  showFilterHint(logins.length);
 }
 
 function searchKeyHandler(e) {

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -203,7 +203,7 @@ function searchPassword(_domain, action="search", useFillOnSubmit=true) {
           logins = resultLogins = response ? response : [];
           document.getElementById("filter-search").textContent = domain;
           fillOnSubmit = useFillOnSubmit && logins.length > 0;
-          if (logins && logins.length > 0) {
+          if (logins.length > 0) {
             showFilterHint(true);
             document.getElementById("search-field").value = '';
           }

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -5,8 +5,8 @@ var FuzzySort = require("fuzzysort");
 var app = "com.dannyvankooten.browserpass";
 var activeTab;
 var searching = false;
-var logins;
-var resultLogins;
+var resultLogins = [];
+var logins = [];
 var fillOnSubmit = false;
 var error;
 var domain, urlDuringSearch;
@@ -30,7 +30,7 @@ function view() {
     if (logins.length === 0) {
       results = m(
         "div.status-text",
-        m.trust(`No passwords found for <strong>${domain}</strong>.`)
+        m.trust(`No matching passwords found for <strong>${domain}</strong>.`)
       );
     } else if (logins.length > 0) {
       results = logins.map(function(login) {
@@ -134,7 +134,7 @@ function searchKeyHandler(e) {
   // switch to search mode if '\' is pressed and no filter text has been entered
   if (e.code == "Backspace" && logins && logins.length > 0 && (!e.target.value.length || e.target.value == domain)) {
     e.preventDefault();
-    logins = resultLogins = null;
+    logins = resultLogins = [];
     e.target.value = '';
     showFilterHint(false);
   }
@@ -182,8 +182,7 @@ function init(tab) {
 
 function searchPassword(_domain, action="search", useFillOnSubmit=true) {
   searching = true;
-  resultLogins = null;
-  logins = null;
+  logins = resultLogins = [];
   domain = _domain;
   urlDuringSearch = activeTab.url;
   m.redraw();
@@ -205,7 +204,7 @@ function searchPassword(_domain, action="search", useFillOnSubmit=true) {
           }
 
           searching = false;
-          logins = resultLogins = response;
+          logins = resultLogins = response ? response : [];
           document.getElementById("filter-search").textContent = domain;
           fillOnSubmit = useFillOnSubmit && logins && logins.length > 0;
           showFilterHint(fillOnSubmit);
@@ -236,8 +235,7 @@ function getFaviconUrl(domain) {
 
 function getLoginData() {
   searching = true;
-  resultLogins = null;
-  logins = null;
+  logins = resultLogins = [];
   m.redraw();
 
   chrome.runtime.sendMessage(

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -64,7 +64,7 @@ function view() {
         "form",
         {
           onsubmit: submitSearchForm,
-          onkeypress: searchKeyHandler
+          onkeydown: searchKeyHandler
         },
         [
           m("input", {
@@ -121,7 +121,7 @@ function filterLogins(e) {
 
 function searchKeyHandler(e) {
   // switch to search mode if '\' is pressed and no filter text has been entered
-  if (e.key == "\\" && (!e.target.value.length || e.target.value == domain)) {
+  if (e.code == "Backspace" && (!e.target.value.length || e.target.value == domain)) {
     e.preventDefault();
     logins = resultLogins = null;
     e.target.value = '';

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -67,20 +67,25 @@ function view() {
           onkeydown: searchKeyHandler
         },
         [
-          m("input", {
-            type: "text",
-            id: "search-field",
-            name: "s",
-            placeholder: "Search password..",
-            autocomplete: "off",
-            autofocus: "on",
-            oninput: filterLogins
+          m("div", {
+            "id": "filter-search"
           }),
-          m("input", {
-            type: "submit",
-            value: "Search",
-            style: "display: none;"
-          })
+          m("div", [
+            m("input", {
+              type: "text",
+              id: "search-field",
+              name: "s",
+              placeholder: "Search password..",
+              autocomplete: "off",
+              autofocus: "on",
+              oninput: filterLogins
+            }),
+            m("input", {
+              type: "submit",
+              value: "Search",
+              style: "display: none;"
+            })
+          ])
         ]
       )
     ]),
@@ -116,7 +121,11 @@ function filterLogins(e) {
     fillOnSubmit = logins.length > 0;
   }
 
+  // redraw the list
   m.redraw();
+
+  // show / hide the filter hint
+  showFilterHint(filter.length > 0 && logins.length);
 }
 
 function searchKeyHandler(e) {
@@ -125,6 +134,16 @@ function searchKeyHandler(e) {
     e.preventDefault();
     logins = resultLogins = null;
     e.target.value = '';
+    showFilterHint(false);
+  }
+}
+
+function showFilterHint(show=true) {
+  var filterHint = document.getElementById("filter-search");
+  if (show) {
+    filterHint.style.display = "block";
+  } else {
+    filterHint.style.display = "none";
   }
 }
 
@@ -182,7 +201,9 @@ function searchPassword(_domain, action="search", useFillOnSubmit=true) {
 
           searching = false;
           logins = resultLogins = response;
+          document.getElementById("filter-search").textContent = domain;
           fillOnSubmit = useFillOnSubmit && logins && logins.length > 0;
+          showFilterHint(fillOnSubmit);
           m.redraw();
         }
       );

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -135,7 +135,7 @@ function filterLogins(e) {
 
 function searchKeyHandler(e) {
   // switch to search mode if '\' is pressed and no filter text has been entered
-  if (e.code == "Backspace" && (!e.target.value.length || e.target.value == domain)) {
+  if (e.code == "Backspace" && logins && logins.length > 0 && (!e.target.value.length || e.target.value == domain)) {
     e.preventDefault();
     logins = resultLogins = null;
     e.target.value = '';

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -132,7 +132,7 @@ function filterLogins(e) {
   m.redraw();
 
   // show / hide the filter hint
-  showFilterHint(e.target.value.length > 0 && logins.length);
+  showFilterHint(e.target.value.length > 0 || (logins && logins.length));
 }
 
 function searchKeyHandler(e) {

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var m = require("mithril");
-var Fuse = require("fuse.js");
+var FuzzySort = require("fuzzysort");
 var app = "com.dannyvankooten.browserpass";
 var activeTab;
 var searching = false;
@@ -102,24 +102,12 @@ function filterLogins(e) {
     e.target.value = e.target.value.substr(domain.length);
   }
 
-  // use fuse.js fuzzy search to filter results
+  // use fuzzy search to filter results
   var filter = e.target.value.trim();
   if (filter.length > 0) {
     logins = [];
-    var fuseOptions = {
-      shouldSort: true,
-      tokenize: true,
-      matchAllTokens: true,
-      threshold: 0.4,
-      location: 0,
-      distance: 100,
-      maxPatternLength: 32,
-      minMatchCharLength: 1,
-      keys: undefined
-    };
-    var fuse = new Fuse(resultLogins, fuseOptions);
-    fuse.search(filter).forEach(function(i) {
-      logins.push(resultLogins[i]);
+    FuzzySort.go(filter, resultLogins, {allowTypo: false}).forEach(function(result) {
+      logins.push(result.target);
     });
 
     // fill login forms on submit rather than initiating a search

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -119,6 +119,7 @@ function filterLogins(e) {
     // fill login forms on submit rather than initiating a search
     fillOnSubmit = logins.length > 0;
   } else {
+    // reset the result list if the filter is empty
     logins = resultLogins.slice(0);
   }
 

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -27,7 +27,7 @@ function view() {
     results = m("div.status-text", "Error: " + error);
     error = undefined;
   } else if (logins) {
-    if (logins.length === 0) {
+    if (logins.length === 0 && domain && domain.length > 0) {
       results = m(
         "div.status-text",
         m.trust(`No matching passwords found for <strong>${domain}</strong>.`)
@@ -131,6 +131,7 @@ function searchKeyHandler(e) {
     e.preventDefault();
     logins = resultLogins = [];
     e.target.value = fillOnSubmit ? '' : domain;
+    domain = '';
     showFilterHint(false);
   }
 }

--- a/chrome/styles.css
+++ b/chrome/styles.css
@@ -7,17 +7,35 @@ body {
   font-size: 14px;
 }
 
+.search > form {
+  border-bottom: 1px solid #bbb;
+  display: flex;
+  flex-wrap: nowrap;
+}
+
+.search > form :last-child {
+  width: 100%;
+}
+
 .search input {
   box-sizing: border-box;
   width: 100%;
   padding: 6px;
   border: 0;
-  border-bottom: 1px solid #bbb;
   background: url("icon-search.svg") center right 6px no-repeat;
   background-size: 16px 16px;
   background-color: white;
   color: black;
   padding-right: 20px;
+}
+
+#filter-search {
+  background: #eee;
+  border: 0;
+  box-sizing: border-box;
+  display: none;
+  padding: 6px;
+  padding-top: 5px;
 }
 
 .search input:focus {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "dependencies": {
     "browserify": "^14.4.0",
     "mithril": "^1.1.4",
-    "fuse.js": "^3.1.0"
+    "fuzzysort": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "browserify": "^14.4.0",
-    "mithril": "^1.1.4"
+    "mithril": "^1.1.4",
+    "fuse.js": "^3.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -376,9 +376,9 @@ function-bind@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
-fuse.js@^3.1.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.2.0.tgz#f0448e8069855bf2a3e683cdc1d320e7e2a07ef4"
+fuzzysort@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/fuzzysort/-/fuzzysort-1.1.1.tgz#bf128f1a4cc6e6b7188665ac5676de46a3d81768"
 
 glob@^7.1.0:
   version "7.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -376,6 +376,10 @@ function-bind@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
+fuse.js@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.2.0.tgz#f0448e8069855bf2a3e683cdc1d320e7e2a07ef4"
+
 glob@^7.1.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"


### PR DESCRIPTION
If there are search results present:
 * Typing in the search field will filter the results.
 * Pressing <kbd>enter</kbd> will autofill the first entry.
 * Pressing <kbd>enter</kbd> when there are no matching entries will run a normal search.

If there are search results present, no filter has been entered, and <kbd>Backspace</kbd> is pressed:
 * All search results are cleared, as is the search input box.
 * Pressing <kbd>enter</kbd> will run a normal search.

The reason for the <kbd>Backspace</kbd> feature is to allow the user to explicitly run a manual search instead of filtering, even when the automatic domain search returns matches.

If the search results are the outcome of a manual search, and no filter text has been entered, then pressing <kbd>enter</kbd> will **not** auto-fill the first entry, but will instead re-run the search. This is to prevent the user accidentally filling a login form by pressing <kbd>enter</kbd> twice when running a manual search.

This PR closes #40 and #211.