### PR TITLE
[SECURITY] Fix for credential leak vector #230

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -107,9 +107,11 @@ function onMessage(request, sender, sendResponse) {
         tabId,
         info
       ) {
-        chrome.tabs.onUpdated.removeListener(tabCompleteListener);
-        tabLoaded = true;
-        request.username = request.password = null;
+        if (tabId == tab.id && info.status == "complete") {
+          chrome.tabs.onUpdated.removeListener(tabCompleteListener);
+          tabLoaded = true;
+          request.username = request.password = null;
+        }
       });
 
       // intercept requests for authentication

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -102,83 +102,79 @@ function onMessage(request, sender, sendResponse) {
       var tabLoaded = false;
       var authAttempted = false;
 
+      // listener function for authentication interception
+      function authListener(requestDetails) {
+        // only supply credentials if this is the first time for this tab, and the tab is not loaded
+        if (authAttempted) {
+          return {};
+        }
+        authAttempted = true;
+
+        // don't supply credentials for loaded tabs
+        if (tabLoaded) {
+          return {};
+        }
+
+        // ask the user before sending credentials to a different domain
+        var launchHost = request.url.match(/:\/\/([^\/]+)/)[1];
+        if (launchHost !== requestDetails.challenger.host) {
+          var message =
+            "You are about to send login credentials to a domain that is different than " +
+            "the one you lauched from the browserpass extension. Do you wish to proceed?\n\n" +
+            "Launched URL: " +
+            request.url +
+            "\n" +
+            "Authentication URL: " +
+            requestDetails.url;
+          if (!confirm(message)) {
+            return {};
+          }
+        }
+
+        // ask the user before sending credentials over an insecure connection
+        if (!requestDetails.url.match(/^https:/i)) {
+          var message =
+            "You are about to send login credentials via an insecure connection!\n\n" +
+            "Are you sure you want to do this? If there is an attacker watching your " +
+            "network traffic, they may be able to see your username and password.\n\n" +
+            "URL: " +
+            requestDetails.url;
+          if (!confirm(message)) {
+            return {};
+          }
+        }
+
+        // supply credentials
+        return {
+          authCredentials: {
+            username: request.username,
+            password: request.password
+          }
+        };
+      }
+
+      // intercept requests for authentication
+      chrome.webRequest.onAuthRequired.addListener(
+        authListener,
+        { urls: ["*://*/*"], tabId: tab.id },
+        ["blocking"]
+      );
+
       // notice when the tab has been loaded
       chrome.tabs.onUpdated.addListener(function tabCompleteListener(
         tabId,
         info
       ) {
         if (tabId == tab.id && info.status == "complete") {
+          // remove listeners
           chrome.tabs.onUpdated.removeListener(tabCompleteListener);
+          chrome.webRequest.onAuthRequired.removeListener(authListener);
+
+          // mark tab as loaded & wipe credentials
           tabLoaded = true;
           request.username = request.password = null;
         }
       });
-
-      // intercept requests for authentication
-      chrome.webRequest.onAuthRequired.addListener(
-        function authListener(requestDetails) {
-          // only supply credentials if this is the first time for this tab, and the tab is not loaded
-          if (authAttempted) {
-            return {};
-          }
-          authAttempted = true;
-
-          // remove event listeners once tab loading is complete
-          chrome.tabs.onUpdated.addListener(function statusListener(
-            tabId,
-            info
-          ) {
-            if (tabId == tab.id && info.status === "complete") {
-              chrome.tabs.onUpdated.removeListener(statusListener);
-              chrome.webRequest.onAuthRequired.removeListener(authListener);
-            }
-          });
-
-          // don't supply credentials for loaded tabs
-          if (tabLoaded) {
-            return {};
-          }
-
-          // ask the user before sending credentials to a different domain
-          var launchHost = request.url.match(/:\/\/([^\/]+)/)[1];
-          if (launchHost !== requestDetails.challenger.host) {
-            var message =
-              "You are about to send login credentials to a domain that is different than " +
-              "the one you lauched from the browserpass extension. Do you wish to proceed?\n\n" +
-              "Launched URL: " +
-              request.url +
-              "\n" +
-              "Authentication URL: " +
-              requestDetails.url;
-            if (!confirm(message)) {
-              return {};
-            }
-          }
-
-          // ask the user before sending credentials over an insecure connection
-          if (!requestDetails.url.match(/^https:/i)) {
-            var message =
-              "You are about to send login credentials via an insecure connection!\n\n" +
-              "Are you sure you want to do this? If there is an attacker watching your " +
-              "network traffic, they may be able to see your username and password.\n\n" +
-              "URL: " +
-              requestDetails.url;
-            if (!confirm(message)) {
-              return {};
-            }
-          }
-
-          // supply credentials
-          return {
-            authCredentials: {
-              username: request.username,
-              password: request.password
-            }
-          };
-        },
-        { urls: ["*://*/*"], tabId: tab.id },
-        ["blocking"]
-      );
     });
   }
 }

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -112,7 +112,7 @@ function onMessage(request, sender, sendResponse) {
             tabId,
             info
           ) {
-            if (info.status === "complete") {
+            if (tabId == tab.id && info.status === "complete") {
               chrome.tabs.onUpdated.removeListener(statusListener);
               chrome.webRequest.onAuthRequired.removeListener(authListener);
             }

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -117,6 +117,21 @@ function onMessage(request, sender, sendResponse) {
               chrome.webRequest.onAuthRequired.removeListener(authListener);
             }
           });
+          // ask the user before sending credentials to a different domain
+          var launchHost = request.url.match(/:\/\/([^\/]+)/)[1];
+          if (launchHost !== requestDetails.challenger.host) {
+            var message =
+              "You are about to send login credentials to a domain that is different than " +
+              "the one you lauched from the browserpass extension. Do you wish to proceed?\n\n" +
+              "Launched URL: " +
+              request.url +
+              "\n" +
+              "Authentication URL: " +
+              requestDetails.url;
+            if (!confirm(message)) {
+              return {};
+            }
+          }
           // ask the user before sending credentials over an insecure connection
           if (!requestDetails.url.match(/^https:/i)) {
             var message =


### PR DESCRIPTION
This PR fixes #230:
 * Credentials are now discarded immediately as soon as the tab has loaded
 * Credentials are not supplied to any model login that occurs after the tab has loaded
 * If the domain requesting credentials is not the same as the domain that was launched, the user will be asked if they really want this.

Once again, I apologise for #230 - that is my fault, and my oversight. I'm usually more careful than that, and I sincerely regret that I allowed this one to slip through.