### PR TITLE
Run prettier through yarn for consistency

### DIFF
--- a/makefile
+++ b/makefile
@@ -18,8 +18,8 @@ endif
 
 .PHONY: prettier
 prettier:
-	prettier --write "chrome/*.js"
-	prettier --write "chrome/*.css"
+	yarn run prettier --write "chrome/*.js"
+	yarn run prettier --write "chrome/*.css"
 
 .PHONY: js
 js: $(JS_OUTPUT)

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "prettier": "prettier"
+  },
   "dependencies": {
     "browserify": "^14.4.0",
     "fuzzysort": "^1.1.0",


### PR DESCRIPTION
My first attempt to build this after some updates resulted in this, which is how I found this issue:

```
% make
yarn
yarn install v1.5.1
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
    2 {¬
[4/4] Building fresh packages...
Done in 1.27s.
dep ensure
prettier --write "chrome/*.js"
bash: prettier: command not found
make: *** [prettier] Error 127
```

The Makefile currently assumes that prettier is installed globally, however it's included in the package.json so it's installed in node_modules. Using `yarn run` will allow us to run prettier without having to modify the PATH to include it (or have to specify the full path manually).

Technically speaking, it isn't required to include prettier in `scripts` but I couldn't find that behavior documented anywhere so I went with the explicit definition.