### PR TITLE
Fix prettier when running from docker

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,9 @@ SHELL := /usr/bin/env bash
 CHROME := $(shell which google-chrome 2>/dev/null || which google-chrome-stable 2>/dev/null || which chromium 2>/dev/null || which chromium-browser 2>/dev/null || which chrome 2>/dev/null)
 PEM := $(shell find . -maxdepth 1 -name "*.pem")
 JS_OUTPUT := chrome/script.js chrome/inject.js chrome/inject_otp.js
-BROWSERIFY := ./node_modules/.bin/browserify
+BROWSERIFY := node_modules/.bin/browserify
+PRETTIER := node_modules/.bin/prettier
+PRETTIER_SOURCES := $(shell find chrome -maxdepth 1 -name "*.js" -o -name "*.css")
 
 all: deps prettier js browserpass
 
@@ -18,8 +20,7 @@ endif
 
 .PHONY: prettier
 prettier:
-	yarn run prettier --write "chrome/*.js"
-	yarn run prettier --write "chrome/*.css"
+	"$(PRETTIER)" --write $(PRETTIER_SOURCES)
 
 .PHONY: js
 js: $(JS_OUTPUT)


### PR DESCRIPTION
`yarn run` for some reason does not pass `--write` to the prettier when executed from the docker container.

So instead of #236 I will do this.

/cc @belak, @erayd 