### PR TITLE
Wrap popup init with settings request

### DIFF
--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -12,11 +12,16 @@ var error;
 var domain, urlDuringSearch;
 var searchSettings;
 
-m.mount(document.getElementById("mount"), { view: view, oncreate: oncreate });
+// load settings and initialise popup
+chrome.runtime.sendMessage({ action: "getSettings" }, function(settings) {
+    searchSettings = settings;
 
-chrome.tabs.onActivated.addListener(init);
-chrome.tabs.query({ lastFocusedWindow: true, active: true }, function(tabs) {
-  init(tabs[0]);
+    m.mount(document.getElementById("mount"), { view: view, oncreate: oncreate });
+
+    chrome.tabs.onActivated.addListener(init);
+    chrome.tabs.query({ lastFocusedWindow: true, active: true }, function(tabs) {
+        init(tabs[0]);
+    });
 });
 
 function view() {


### PR DESCRIPTION
Ensures that the `searchSettings` object is available before the popup is first rendered.

Possibly related to #245.