### PR TITLE
Add per-site autosubmit

### DIFF
--- a/browserpass.go
+++ b/browserpass.go
@@ -24,8 +24,7 @@ type Login struct {
 	OTP        string `json:"digits"`
 	OTPLabel   string `json:"label"`
 	URL        string `json:"url"`
-	ASOverride bool   `json:"asOverride"`
-	AutoSubmit bool   `json:"autoSubmit"`
+	AutoSubmit bool   `json:"autoSubmit,omitempty"`
 }
 
 var endianness = binary.LittleEndian
@@ -249,7 +248,6 @@ func parseLogin(r io.Reader) (*Login, error) {
 		}
 		replaced = asPattern.ReplaceAllString(line, "")
 		if len(replaced) != len(line) {
-			login.ASOverride = true;
 			asString := strings.TrimSpace(replaced);
 			if (asString == "true") {
 				login.AutoSubmit = true;

--- a/browserpass.go
+++ b/browserpass.go
@@ -24,7 +24,7 @@ type Login struct {
 	OTP        string `json:"digits"`
 	OTPLabel   string `json:"label"`
 	URL        string `json:"url"`
-	AutoSubmit bool   `json:"autoSubmit,omitempty"`
+	AutoSubmit *bool  `json:"autoSubmit,omitempty"`
 }
 
 var endianness = binary.LittleEndian
@@ -249,10 +249,12 @@ func parseLogin(r io.Reader) (*Login, error) {
 		replaced = asPattern.ReplaceAllString(line, "")
 		if len(replaced) != len(line) {
 			asString := strings.TrimSpace(replaced);
+			var autoSubmit bool;
+			login.AutoSubmit = &autoSubmit;
 			if (asString == "true") {
-				login.AutoSubmit = true;
+				autoSubmit = true;
 			} else {
-				login.AutoSubmit = false;
+				autoSubmit = false;
 			}
 		}
 	}

--- a/browserpass.go
+++ b/browserpass.go
@@ -38,7 +38,7 @@ var endianness = binary.LittleEndian
 // Config defines the root config structure sent from the browser extension
 type Config struct {
 	// Manual searches use FuzzySearch if true, GlobSearch otherwise
-	UseFuzzy    bool                    `json:"use_fuzzy_search"`
+	UseFuzzy     bool                   `json:"use_fuzzy_search"`
 	CustomStores []pass.StoreDefinition `json:"customStores"`
 }
 
@@ -232,29 +232,29 @@ func parseLogin(r io.Reader) (*Login, error) {
 	// Keep reading file for string in "login:", "username:" or "user:" format (case insensitive).
 	userPattern := regexp.MustCompile("(?i)^(login|username|user):")
 	urlPattern := regexp.MustCompile("(?i)^(url|link|website|web|site):")
-	asPattern := regexp.MustCompile("(?i)^autosubmit:")
+	autoSubmitPattern := regexp.MustCompile("(?i)^autosubmit:")
 	for scanner.Scan() {
 		line := scanner.Text()
-		parseTotp(line, login)
-		replaced := userPattern.ReplaceAllString(line, "")
-		if len(replaced) != len(line) {
-			login.Username = strings.TrimSpace(replaced)
+		if login.OTP == "" {
+			parseTotp(line, login)
+		}
+		if login.Username == "" {
+			replaced := userPattern.ReplaceAllString(line, "")
+			if len(replaced) != len(line) {
+				login.Username = strings.TrimSpace(replaced)
+			}
 		}
 		if login.URL == "" {
-			replaced = urlPattern.ReplaceAllString(line, "")
+			replaced := urlPattern.ReplaceAllString(line, "")
 			if len(replaced) != len(line) {
 				login.URL = strings.TrimSpace(replaced)
 			}
 		}
-		replaced = asPattern.ReplaceAllString(line, "")
-		if len(replaced) != len(line) {
-			asString := strings.TrimSpace(replaced);
-			var autoSubmit bool;
-			login.AutoSubmit = &autoSubmit;
-			if (asString == "true") {
-				autoSubmit = true;
-			} else {
-				autoSubmit = false;
+		if login.AutoSubmit == nil {
+			replaced := autoSubmitPattern.ReplaceAllString(line, "")
+			if len(replaced) != len(line) {
+				value := strings.ToLower(strings.TrimSpace(replaced)) == "true"
+				login.AutoSubmit = &value
 			}
 		}
 	}

--- a/browserpass.go
+++ b/browserpass.go
@@ -19,11 +19,13 @@ import (
 
 // Login represents a single pass login.
 type Login struct {
-	Username string `json:"u"`
-	Password string `json:"p"`
-	OTP      string `json:"digits"`
-	OTPLabel string `json:"label"`
-	URL      string `json:"url"`
+	Username   string `json:"u"`
+	Password   string `json:"p"`
+	OTP        string `json:"digits"`
+	OTPLabel   string `json:"label"`
+	URL        string `json:"url"`
+	ASOverride bool   `json:"asOverride"`
+	AutoSubmit bool   `json:"autoSubmit"`
 }
 
 var endianness = binary.LittleEndian
@@ -231,6 +233,7 @@ func parseLogin(r io.Reader) (*Login, error) {
 	// Keep reading file for string in "login:", "username:" or "user:" format (case insensitive).
 	userPattern := regexp.MustCompile("(?i)^(login|username|user):")
 	urlPattern := regexp.MustCompile("(?i)^(url|link|website|web|site):")
+	asPattern := regexp.MustCompile("(?i)^autosubmit:")
 	for scanner.Scan() {
 		line := scanner.Text()
 		parseTotp(line, login)
@@ -242,6 +245,16 @@ func parseLogin(r io.Reader) (*Login, error) {
 			replaced = urlPattern.ReplaceAllString(line, "")
 			if len(replaced) != len(line) {
 				login.URL = strings.TrimSpace(replaced)
+			}
+		}
+		replaced = asPattern.ReplaceAllString(line, "")
+		if len(replaced) != len(line) {
+			login.ASOverride = true;
+			asString := strings.TrimSpace(replaced);
+			if (asString == "true") {
+				login.AutoSubmit = true;
+			} else {
+				login.AutoSubmit = false;
 			}
 		}
 	}

--- a/chrome/background.browserify.js
+++ b/chrome/background.browserify.js
@@ -76,7 +76,7 @@ function onMessage(request, sender, sendResponse) {
           ) {
             // do not send login data to page if URL changed during search.
             if (tabs[0].url == request.urlDuringSearch) {
-              var autoSubmit = response.asOverride ? response.autoSubmit : getSettings().autoSubmit;
+              var autoSubmit = response.hasOwnProperty('autoSubmit') ? response.autoSubmit : getSettings().autoSubmit;
               fillLoginForm(response, tabs[0], autoSubmit);
             }
           });

--- a/chrome/background.browserify.js
+++ b/chrome/background.browserify.js
@@ -12,7 +12,7 @@ chrome.tabs.onUpdated.addListener(onTabUpdated);
 chrome.runtime.onInstalled.addListener(onExtensionInstalled);
 
 // fill login form & submit
-function fillLoginForm(login, tab) {
+function fillLoginForm(login, tab, autoSubmit) {
   const loginParam = JSON.stringify(login);
   chrome.tabs.executeScript(
     tab.id,
@@ -23,7 +23,7 @@ function fillLoginForm(login, tab) {
     function() {
       chrome.tabs.executeScript({
         allFrames: true,
-        code: `browserpassFillForm(${loginParam}, ${getSettings().autoSubmit});`
+        code: `browserpassFillForm(${loginParam}, ${autoSubmit});`
       });
     }
   );
@@ -76,7 +76,8 @@ function onMessage(request, sender, sendResponse) {
           ) {
             // do not send login data to page if URL changed during search.
             if (tabs[0].url == request.urlDuringSearch) {
-              fillLoginForm(response, tabs[0]);
+              var autoSubmit = response.asOverride ? response.autoSubmit : getSettings().autoSubmit;
+              fillLoginForm(response, tabs[0], autoSubmit);
             }
           });
 


### PR DESCRIPTION
Adds per-site autosubmit by allowing `autosubmit: <true|false>` in password files to override the global config option.

Requires a host app update to work, but using this version of the extension with the old host app will degrade gracefully.

Closes #251.