### PR TITLE
Add option to filter all entries

### DIFF
--- a/chrome/background.browserify.js
+++ b/chrome/background.browserify.js
@@ -247,6 +247,7 @@ function getSettings() {
   var settings = {
     autoSubmit: false,
     use_fuzzy_search: true,
+    filterEverything: false,
     customStores: []
   };
 

--- a/chrome/options.browserify.js
+++ b/chrome/options.browserify.js
@@ -9,6 +9,11 @@ var settings = {
     title: "Use fuzzy search",
     value: true
   },
+  filterEverything: {
+    type: "checkbox",
+    title: "Filter all available entries",
+    value: false
+  },
   customStores: {
     title: "Custom password store locations",
     value: [{ enabled: true, name: "", path: "" }]

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -234,6 +234,7 @@ function searchPassword(_domain, action = "search", useFillOnSubmit = true) {
   if (!_domain.length || ignore.indexOf(_domain) >= 0) {
     if (searchSettings.filterEverything) {
       searchPassword("*", "match_domain");
+      domain = "*";
     }
     return;
   }

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -36,7 +36,7 @@ function view() {
     if (logins.length === 0 && domain && domain.length > 0) {
       results = m(
         "div.status-text",
-        m.trust(`No matching passwords found for <strong>${domain}</strong>.`)
+        m.trust(`No matching passwords found` + (domain == "*" ? `.` : ` for <strong>${domain}</strong>.`))
       );
     } else if (logins.length > 0) {
       results = logins.map(function(login) {

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -267,7 +267,7 @@ function searchPassword(_domain, action = "search", useFillOnSubmit = true) {
 
         logins = resultLogins = response ? response : [];
         document.getElementById("filter-search").textContent = domain;
-        fillOnSubmit = useFillOnSubmit && logins.length > 0;
+        fillOnSubmit = useFillOnSubmit && logins.length > 0 && domain != "*";
         if (logins.length > 0) {
           showFilterHint(true);
           document.getElementById("search-field").value = "";

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -179,7 +179,6 @@ function searchKeyHandler(e) {
     e.target.value = fillOnSubmit ? "" : domain;
     if (searchSettings.filterEverything && domain != "*") {
       searchPassword('*', "match_domain");
-      domain = "*";
     } else {
       showFilterHint(false);
       logins = resultLogins = [];
@@ -234,7 +233,6 @@ function searchPassword(_domain, action = "search", useFillOnSubmit = true) {
   if (!_domain.length || ignore.indexOf(_domain) >= 0) {
     if (searchSettings.filterEverything) {
       searchPassword("*", "match_domain", false);
-      domain = "*";
     }
     return;
   }

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -269,7 +269,7 @@ function searchPassword(_domain, action = "search", useFillOnSubmit = true) {
         if (logins.length > 0) {
           showFilterHint(true);
           document.getElementById("search-field").value = "";
-        } else if (domain == parseDomainFromUrl(activeTab.url)) {
+        } else if (searchSettings.filterEverything && domain == parseDomainFromUrl(activeTab.url)) {
 	  searchPassword("*", "match_domain", false);
 	}
         m.redraw();

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -271,7 +271,9 @@ function searchPassword(_domain, action = "search", useFillOnSubmit = true) {
         if (logins.length > 0) {
           showFilterHint(true);
           document.getElementById("search-field").value = "";
-        }
+        } else {
+	  searchPassword("*", "match_domain");
+	}
         m.redraw();
       }
     );

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -176,7 +176,7 @@ function searchKeyHandler(e) {
     e.target.value.length == 0
   ) {
     e.preventDefault();
-    e.target.value = fillOnSubmit ? "" : domain;
+    e.target.value = (fillOnSubmit || domain == "*") ? "" : domain;
     if (searchSettings.filterEverything && domain != "*") {
       searchPassword('*', "match_domain");
       domain = "*";

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -176,10 +176,15 @@ function searchKeyHandler(e) {
     e.target.value.length == 0
   ) {
     e.preventDefault();
-    logins = resultLogins = [];
     e.target.value = fillOnSubmit ? "" : domain;
-    domain = "";
-    showFilterHint(false);
+    if (searchSettings.filterEverything && domain != "*") {
+      searchPassword('*', "match_domain");
+      domain = "*";
+    } else {
+      showFilterHint(false);
+      logins = resultLogins = [];
+      domain = "";
+    }
   }
 }
 
@@ -227,6 +232,9 @@ function searchPassword(_domain, action = "search", useFillOnSubmit = true) {
   _domain = _domain.trim();
   var ignore = ["newtab", "extensions"];
   if (!_domain.length || ignore.indexOf(_domain) >= 0) {
+    if (searchSettings.filterEverything) {
+      searchPassword("*", "match_domain");
+    }
     return;
   }
 

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -271,7 +271,7 @@ function searchPassword(_domain, action = "search", useFillOnSubmit = true) {
         if (logins.length > 0) {
           showFilterHint(true);
           document.getElementById("search-field").value = "";
-        } else {
+        } else if (domain == parseDomainFromUrl(activeTab.url)) {
 	  searchPassword("*", "match_domain", false);
 	}
         m.redraw();

--- a/chrome/script.browserify.js
+++ b/chrome/script.browserify.js
@@ -176,7 +176,7 @@ function searchKeyHandler(e) {
     e.target.value.length == 0
   ) {
     e.preventDefault();
-    e.target.value = (fillOnSubmit || domain == "*") ? "" : domain;
+    e.target.value = fillOnSubmit ? "" : domain;
     if (searchSettings.filterEverything && domain != "*") {
       searchPassword('*', "match_domain");
       domain = "*";
@@ -233,7 +233,7 @@ function searchPassword(_domain, action = "search", useFillOnSubmit = true) {
   var ignore = ["newtab", "extensions"];
   if (!_domain.length || ignore.indexOf(_domain) >= 0) {
     if (searchSettings.filterEverything) {
-      searchPassword("*", "match_domain");
+      searchPassword("*", "match_domain", false);
       domain = "*";
     }
     return;
@@ -267,12 +267,12 @@ function searchPassword(_domain, action = "search", useFillOnSubmit = true) {
 
         logins = resultLogins = response ? response : [];
         document.getElementById("filter-search").textContent = domain;
-        fillOnSubmit = useFillOnSubmit && logins.length > 0 && domain != "*";
+        fillOnSubmit = useFillOnSubmit && logins.length > 0;
         if (logins.length > 0) {
           showFilterHint(true);
           document.getElementById("search-field").value = "";
         } else {
-	  searchPassword("*", "match_domain");
+	  searchPassword("*", "match_domain", false);
 	}
         m.redraw();
       }

--- a/chrome/styles.css
+++ b/chrome/styles.css
@@ -5,7 +5,10 @@ body {
   min-width: 350px;
   background: white;
   font-size: 14px;
-  overflow-y: hidden;
+}
+
+.container {
+  max-height: 300px;
 }
 
 .search > form {
@@ -51,6 +54,8 @@ body {
 .results {
   width: 100%;
   min-width: 160px;
+  max-height: inherit;
+  overflow-y: auto;
 }
 
 .entry {


### PR DESCRIPTION
A few people have asked about this, so here's a PR that implements it. The feature needs to be explicitly enabled, and defaults to off.

Note that 'filter everything' mode is *not* triggered when all results from a search are filtered out, in order to prevent accidental submission of non-domain credentials after an automatic domain search.

If the 'filter everything' option is enabled, then will enter 'filtering everything' mode:
 * If pressing backspace to clear a search.
 * If opening from a tab that does not match a domain.

If in 'filtering everything' mode:
 * Pressing backspace will exit to normal search mode.